### PR TITLE
Make hanami routes work with nested non-hanami apps

### DIFF
--- a/lib/hanami/routing/route.rb
+++ b/lib/hanami/routing/route.rb
@@ -45,13 +45,12 @@ module Hanami
       end
 
       # Introspect the given route to understand if there is a wrapped
-      # Hanami::Router
+      # router that has an inspector
       #
       # @since 0.2.0
       # @api private
       def nested_router
-        dest.routes if dest.respond_to?(:routes) &&
-          dest.routes.is_a?(Hanami::Router)
+        dest.routes if dest.respond_to?(:routes) && dest.routes.respond_to?(:inspector)
       end
 
       private

--- a/lib/hanami/routing/route.rb
+++ b/lib/hanami/routing/route.rb
@@ -50,7 +50,8 @@ module Hanami
       # @since 0.2.0
       # @api private
       def nested_router
-        dest.routes if dest.respond_to?(:routes)
+        dest.routes if dest.respond_to?(:routes) &&
+          dest.routes.is_a?(Hanami::Router)
       end
 
       private

--- a/test/routing/routes_inspector_test.rb
+++ b/test/routing/routes_inspector_test.rb
@@ -224,10 +224,18 @@ describe Hanami::Routing::RoutesInspector do
           mount inner_router, at: '/second_mount'
         }
 
+        nested_non_hanami_router = Object.new
+        def nested_non_hanami_router.call(env)
+        end
+        def nested_non_hanami_router.routes
+          return {}
+        end
+
         @router = Hanami::Router.new do
           get '/fakeroute', to: 'fake#index'
           mount AdminHanamiApp,  at: '/admin'
           mount nested_router,  at: '/api'
+          mount nested_non_hanami_router, at: '/foo'
           mount RackMiddleware, at: '/class'
           mount RackMiddlewareInstanceMethod,     at: '/instance_from_class'
           mount RackMiddlewareInstanceMethod.new, at: '/instance'
@@ -243,7 +251,8 @@ describe Hanami::Routing::RoutesInspector do
           %(| GET, HEAD |  | /api/second_mount/comments | Comments::Index |),
           %(|  |  | /class | RackMiddleware |),
           %(|  |  | /instance_from_class | #<RackMiddlewareInstanceMethod> |),
-          %(|  |  | /instance | #<RackMiddlewareInstanceMethod> |)
+          %(|  |  | /instance | #<RackMiddlewareInstanceMethod> |),
+          %(|  |  | /foo | #<Object> |)
         ]
 
         actual = @router.inspector.to_s(formatter)


### PR DESCRIPTION
Why you made the change:

I did this so that non-hanami applications like Sinatra, apps, etc. when
mounted will still allow the `hanami routes` command line interface to
work.

How the change addresses the need:

As discussed in issue #92 there is an issue where when a non-hanami
application is mounted that responds to the `routes` method that doesn't
return a `Hanami::Router` it throws an exception. This change fixes that
by identifying non-hanami nested routers properly rather than just doing
it based the application responding to the `routes` method.

---

Closes #92 