### PR TITLE
Add root route

### DIFF
--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -491,6 +491,37 @@ module Hanami
       @router.trace(path, options, &blk)
     end
 
+    # Defines a root route (a GET route for '/')
+    #
+    # @param options [Hash] the options to customize the route
+    # @option options [String,Proc,Class,Object#call] :to the endpoint
+    #
+    # @param blk [Proc] the anonymous proc to be used as endpoint for the route
+    #
+    # @return [Hanami::Routing::Route] this may vary according to the :route
+    #   option passed to the constructor
+    #
+    # @since 0.6.2
+    #
+    # @example Fixed matching string
+    #   require 'hanami/router'
+    #
+    #   router = Hanami::Router.new
+    #   router.root , to: ->(env) { [200, {}, ['Hello from Hanami!']] }
+    #
+    # @example Included names as `root` (for path and url helpers)
+    #   require 'hanami/router'
+    #
+    #   router = Hanami::Router.new(scheme: 'https', host: 'hanamirb.org')
+    #   router.root, to: ->(env) { [200, {}, ['Hello from Hanami!']] }
+    #
+    #   router.path(:root) # => "/"
+    #   router.url(:root)  # => "https://hanamirb.org/"
+    def root(options = {}, &blk)
+      options.merge!({ as: :root})
+      @router.get('/', options, &blk)
+    end
+
     # Defines a route that accepts a OPTIONS request for the given path.
     #
     # @param path [String] the relative URL to be matched

--- a/test/new_test.rb
+++ b/test/new_test.rb
@@ -8,6 +8,7 @@ describe Hanami::Router do
 
       endpoint = ->(env) { [200, {}, ['']] }
       @router = Hanami::Router.new do
+        root                to: endpoint
         get '/route',       to: endpoint
         get '/named_route', to: endpoint, as: :named_route
         resource  'avatar'
@@ -42,7 +43,7 @@ describe Hanami::Router do
 
     it 'sets options' do
       router = Hanami::Router.new(scheme: 'https') do
-        get '/', to: ->(env) { }, as: :root
+        root to: ->(env) { }
       end
 
       router.url(:root).must_match('https')
@@ -50,7 +51,7 @@ describe Hanami::Router do
 
     it 'sets custom separator' do
       router = Hanami::Router.new(action_separator: '^')
-      route  = router.get('/', to: 'test^show', as: :root)
+      route  = router.root(to: 'test^show')
 
       route.dest.must_equal(Test::Show)
     end
@@ -61,6 +62,10 @@ describe Hanami::Router do
 
       router = Hanami::Router.new { get '/', to: ->(env) { } }
       router.must_be :defined?
+    end
+
+    it 'recognizes root' do
+      @app.get('/', lint: true).status.must_equal 200
     end
 
     it 'recognizes path' do

--- a/test/routing/routes_inspector_test.rb
+++ b/test/routing/routes_inspector_test.rb
@@ -10,6 +10,7 @@ describe Hanami::Routing::RoutesInspector do
     describe 'named routes with procs' do
       before do
         @router = Hanami::Router.new do
+          root           to: ->(env) { }
           get '/login',  to: ->(env) { },       as: :login
           get '/logout', to: Proc.new {|env| }, as: :logout
         end
@@ -17,8 +18,9 @@ describe Hanami::Routing::RoutesInspector do
 
       it 'inspects routes' do
         expectations = [
-          %( login GET, HEAD  /login                         #<Proc@#{ @path }:13 (lambda)>),
-          %(logout GET, HEAD  /logout                        #<Proc@#{ @path }:14>)
+          %(  root GET, HEAD  /                              #<Proc@#{ @path }:13 (lambda)>),
+          %( login GET, HEAD  /login                         #<Proc@#{ @path }:14 (lambda)>),
+          %(logout GET, HEAD  /logout                        #<Proc@#{ @path }:15>)
         ]
 
         actual = @router.inspector.to_s
@@ -193,7 +195,7 @@ describe Hanami::Routing::RoutesInspector do
       it 'inspects routes' do
         formatter     = "| %{methods} | %{name} | %{path} | %{endpoint} |\n"
         expectations  = [
-          %(| GET, HEAD | login | /login | #<Proc@#{ @path }:189 (lambda)> |)
+          %(| GET, HEAD | login | /login | #<Proc@#{ @path }:191 (lambda)> |)
         ]
 
         actual = @router.inspector.to_s(formatter)

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -89,7 +89,36 @@ describe Hanami::Router do
           @app.request(verb.upcase, '/hanami/flower', lint: true).status.must_equal 404
         end
       end
+    end
 
-    end # main each
+  end # main each
+
+  describe 'root' do
+    describe 'path recognition' do
+      it 'recognize fixed string' do
+        response = [200, {}, ['Fixed!']]
+        @router.root(to: ->(env) { response })
+
+        response.must_be_same_as @app.request('GET', '/', lint: true)
+      end
+
+      it 'accepts a block' do
+        response = [200, {}, ['Block!']]
+        @router.root {|e| response }
+
+        response.must_be_same_as @app.request('GET', '/', lint: true)
+      end
+    end
+
+    describe 'named route for root' do
+      it 'recognizes by the given symbol' do
+        response = [200, {}, ['Named route!']]
+
+        @router.root(to: ->(env) { response })
+
+        @router.path(:root).must_equal '/'
+        @router.url(:root).must_equal  'http://localhost/'
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #97.

The guides will need to be updated, which I can do after this is merged. 

Do you think we should add support for missing the `to:`? e.g. `root "welcome#index"`
[Rails has this shortcut](http://guides.rubyonrails.org/routing.html#using-root) and it's nice.