### PR TITLE
Match against host

### DIFF
--- a/lib/hanami/routing/http_router.rb
+++ b/lib/hanami/routing/http_router.rb
@@ -143,7 +143,7 @@ module Hanami
       # @since 0.1.1
       # @api private
       def mount(app, options)
-        add("#{ options.fetch(:at) }*").to(
+        add("#{ options.fetch(:at) }*", host: options[:host]).to(
           @resolver.resolve(to: app)
         )
       end

--- a/test/integration/router_container_test.rb
+++ b/test/integration/router_container_test.rb
@@ -13,4 +13,17 @@ describe 'Router wrapper as container' do
     response = @app.get('/back/home', lint: true)
     response.body.must_equal 'back'
   end
+
+  it 'matches against host' do
+    @router_container = Hanami::Router.new(scheme: 'https', host: 'hanami.test', port: 443) do
+      mount Front::App, at: '/front', host: 'www.hanami.test'
+      mount Back::App, at: '/front'
+    end
+
+    @app = Rack::MockRequest.new(@router_container)
+    response = @app.get('https://www.hanami.test/front/home', lint: true)
+    response.body.must_equal 'front'
+    response = @app.get('/front/home', lint: true)
+    response.body.must_equal 'back'
+  end
 end

--- a/test/integration/router_container_test.rb
+++ b/test/integration/router_container_test.rb
@@ -23,7 +23,7 @@ describe 'Router wrapper as container' do
     @app = Rack::MockRequest.new(@router_container)
     response = @app.get('https://www.hanami.test/front/home', lint: true)
     response.body.must_equal 'front'
-    response = @app.get('/front/home', lint: true)
+    response = @app.get('https://hanami.test/front/home', lint: true)
     response.body.must_equal 'back'
   end
 end


### PR DESCRIPTION
This way it's possible to mount different containers on different domains. E.g.:

```
Hanami::Container.configure do
  mount Admin::Application, at: '/', host: 'admin.hanami.dev'
  mount Web::Application, at: '/'
end
```