### PR TITLE
Move default response to a constant

### DIFF
--- a/lib/hanami/routing/endpoint_resolver.rb
+++ b/lib/hanami/routing/endpoint_resolver.rb
@@ -14,7 +14,7 @@ module Hanami
       # @api private
       NAMING_PATTERN = '%{controller}::%{action}'.freeze
 
-      # @since 0.8.0
+      # @since x.x.x
       # @api private
       DEFAULT_RESPONSE = [404, {'X-Cascade' => 'pass'}, 'Not Found'].freeze
 

--- a/lib/hanami/routing/endpoint_resolver.rb
+++ b/lib/hanami/routing/endpoint_resolver.rb
@@ -14,6 +14,10 @@ module Hanami
       # @api private
       NAMING_PATTERN = '%{controller}::%{action}'.freeze
 
+      # @since 0.8.0
+      # @api private
+      DEFAULT_RESPONSE = [404, {'X-Cascade' => 'pass'}, 'Not Found'].freeze
+
       # Default separator for controller and action.
       # A different separator can be passed to #initialize with the `:separator` option.
       #
@@ -178,7 +182,7 @@ module Hanami
       protected
       def default
         @endpoint_class.new(
-          ->(env) { [404, {'X-Cascade' => 'pass'}, 'Not Found'] }
+          ->(env) { DEFAULT_RESPONSE }
         )
       end
 


### PR DESCRIPTION
Not really sure about this PR, so I'd love to get your feedback about this small refactor.

Was thinking of moving the default response to a frozen constant, seeing that most literals in Hanami are constantized. It might save Ruby a few cycles from allocating new objects whenever the router's default endpoint needs to be called.

I also did a micro benchmark and it showed some promise:

```ruby
require 'benchmark/ips'
require 'hanami/router'

DEFAULT_RESPONSE = [404, {'X-Cascade' => 'pass'}, 'Not Found'].freeze

Benchmark.ips do |bm|
  bm.report 'literal' do
    Hanami::Routing::Endpoint.new(
      ->(env) { [404, {'X-Cascade' => 'pass'}, 'Not Found'] }
    ).call({})
  end

  bm.report 'constant' do
    Hanami::Routing::Endpoint.new(
      ->(env) { DEFAULT_RESPONSE }
    ).call({})
  end

  bm.compare!
end
```

```
Warming up --------------------------------------
             literal    31.706k i/100ms
            constant    46.534k i/100ms
Calculating -------------------------------------
             literal    358.765k (± 4.9%) i/s -      1.807M in   5.050570s
            constant    575.036k (± 3.9%) i/s -      2.885M in   5.025164s

Comparison:
            constant:   575036.2 i/s
             literal:   358765.5 i/s - 1.60x slower
```