### PR TITLE
Failing test for 404 when no GET root

### DIFF
--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -108,6 +108,13 @@ describe Hanami::Router do
 
         response.must_be_same_as @app.request('GET', '/', lint: true)
       end
+
+      it 'handles not found on GET when only POST root is defined' do
+        @router.post("/", to: ->(_env) { [201, {}, [""]] })
+
+        status, _, _ = @app.request('GET', '/bogus', lint: true)
+        status.must_equal(404)
+      end
     end
 
     describe 'named route for root' do


### PR DESCRIPTION
I have an app where there is no `GET /` route defined, but a `POST /` is defined (and several other GET routes).

This seems to mess up response status code for GET requests that does not resolve to a route.

See failing spec, which fails with message

```
  1) Failure:
Hanami::Router::root::path recognition#test_0003_handles not found on GET when only POST root is defined [/vagrant/hanami-router/test/routing_test.rb:116]:
Expected: 404
  Actual: 405
```

Is this behaviour somehow by design?
