### PR TITLE
Add parsed body to env

### DIFF
--- a/lib/hanami/routing/parsers.rb
+++ b/lib/hanami/routing/parsers.rb
@@ -8,6 +8,7 @@ module Hanami
 
       RACK_INPUT    = 'rack.input'.freeze
       ROUTER_PARAMS = 'router.params'.freeze
+      ROUTER_PARSED_BODY = 'router.parsed_body'.freeze
       FALLBACK_KEY  = '_'.freeze
 
       def initialize(parsers)
@@ -47,9 +48,9 @@ module Hanami
           env[RACK_INPUT].rewind    # somebody might try to read this stream
 
           env[ROUTER_PARAMS] ||= {} # prepare params
-          env[ROUTER_PARAMS].merge!(
-            _parse(env, body)
-          )
+          parsed_body = _parse(env, body)
+          env[ROUTER_PARSED_BODY] = parsed_body
+          env[ROUTER_PARAMS].merge!(parsed_body)
 
           env
         end

--- a/test/routing/parsers_test.rb
+++ b/test/routing/parsers_test.rb
@@ -49,12 +49,22 @@ describe Hanami::Routing::Parsers do
           result['router.params'].must_equal({"attribute" => "ok"})
         end
 
+        it "stores parsed body" do
+          result = @parsers.call(env)
+          result['router.parsed_body'].must_equal({"attribute" => "ok"})
+        end
+
         describe "with non hash body" do
           let(:body) { %(["foo"]) }
 
           it "parses params from body" do
             result = @parsers.call(env)
             result['router.params'].must_equal({"_" => ["foo"]})
+          end
+
+          it "stores parsed body" do
+            result = @parsers.call(env)
+            result['router.parsed_body'].must_equal({"_" => ["foo"]})
           end
         end
 
@@ -73,6 +83,11 @@ describe Hanami::Routing::Parsers do
         it "parses params from body" do
           result = @parsers.call(env)
           result['router.params'].must_equal({"attribute" => "ok"})
+        end
+
+        it "stores parsed body" do
+          result = @parsers.call(env)
+          result['router.parsed_body'].must_equal({"attribute" => "ok"})
         end
 
         describe 'with malformed json' do


### PR DESCRIPTION
I did this because I want to access the body parsed with the body parsers outside of `Action#params`.  Currently the parsed body attributes are merged with route/query params as `#params`, which makes it impossible to know the source of a parameter.