### PR TITLE
Avoid symbolizing keys of parsed body.

### DIFF
--- a/lib/hanami/routing/parsers.rb
+++ b/lib/hanami/routing/parsers.rb
@@ -51,23 +51,25 @@ module Hanami
           env[ROUTER_PARAMS] ||= {} # prepare params
           parsed_body = _parse(env, body)
           env[ROUTER_PARSED_BODY] = parsed_body
-          env[ROUTER_PARAMS]      = parsed_body.merge(env[ROUTER_PARAMS])
+          symbolized_body = _symbolize(parsed_body)
+          env[ROUTER_PARAMS] = symbolized_body.merge(env[ROUTER_PARAMS])
 
           env
         end
       end
 
+      def _symbolize(body)
+        if body.is_a?(Hash)
+          Utils::Hash.new(body).deep_dup.symbolize!.to_h
+        else
+          { FALLBACK_KEY => body }
+        end
+      end
+
       def _parse(env, body)
-        result = @parsers[
+        @parsers[
           media_type(env)
         ].parse(body)
-
-        case result
-        when Hash
-          Utils::Hash.new(result).symbolize!.to_h
-        else
-          {FALLBACK_KEY => result}
-        end
       end
 
       def media_type(env)

--- a/test/routing/parsers_test.rb
+++ b/test/routing/parsers_test.rb
@@ -51,7 +51,7 @@ describe Hanami::Routing::Parsers do
 
         it "stores parsed body" do
           result = @parsers.call(env)
-          result['router.parsed_body'].must_equal({attribute: "ok"})
+          result['router.parsed_body'].must_equal({'attribute' => "ok"})
         end
 
         describe "with non hash body" do
@@ -64,7 +64,7 @@ describe Hanami::Routing::Parsers do
 
           it "stores parsed body" do
             result = @parsers.call(env)
-            result['router.parsed_body'].must_equal({"_" => ["foo"]})
+            result['router.parsed_body'].must_equal(["foo"])
           end
         end
 
@@ -87,7 +87,7 @@ describe Hanami::Routing::Parsers do
 
         it "stores parsed body" do
           result = @parsers.call(env)
-          result['router.parsed_body'].must_equal({attribute: "ok"})
+          result['router.parsed_body'].must_equal({'attribute' => "ok"})
         end
 
         describe 'with malformed json' do


### PR DESCRIPTION
Some middleware may need to access the pristine parsed body (via `env['router.parsed_body']`). Currently, the keys of this hash get symbolized (which is desirable for `env['router.params']` for consistency).

This PR makes it so that the keys are only symbolized in `env['router.params']`, and not in `env['router.parsed_body']`.