### PR TITLE
:as option for RESTful routes

### DIFF
--- a/lib/hanami/routing/resource/action.rb
+++ b/lib/hanami/routing/resource/action.rb
@@ -258,7 +258,8 @@ module Hanami
         # @api private
         # @since 0.4.0
         def _singularized_as
-          resource_name.split(NESTED_ROUTES_SEPARATOR).map do |name|
+          name = @options[:as] ? @options[:as].to_s : resource_name
+          name.split(NESTED_ROUTES_SEPARATOR).map do |name|
             Hanami::Utils::String.new(name).singularize
           end
         end

--- a/test/named_routes_test.rb
+++ b/test/named_routes_test.rb
@@ -9,6 +9,8 @@ describe Hanami::Router do
     @router.get('/books/:id',   id: /\d+/, to: endpoint, as: :constraints)
     @router.get('/articles(.:format)',     to: endpoint, as: :optional)
     @router.get('/files/*',                to: endpoint, as: :glob)
+    @router.resources(:leaves,                           as: :resources)
+    @router.resource(:stem,                              as: :singular_resource)
   end
 
   after do
@@ -75,6 +77,38 @@ describe Hanami::Router do
       }.must_raise(Hanami::Routing::InvalidRouteException)
 
       exception.message.must_equal 'HttpRouter::TooManyParametersException - please check given arguments'
+    end
+
+    describe 'plural resource routes' do
+      it 'recognizes index' do
+        @router.url(:resources).must_equal 'https://test.com/leaves'
+      end
+
+      it 'recognizes new' do
+        @router.url(:new_resource).must_equal 'https://test.com/leaves/new'
+      end
+
+      it 'recognizes edit' do
+        @router.url(:edit_resource, id: 1).must_equal 'https://test.com/leaves/1/edit'
+      end
+
+      it 'recognizes show' do
+        @router.url(:resource, id: 1).must_equal 'https://test.com/leaves/1'
+      end
+    end
+
+    describe 'singular resource routes' do
+      it 'recognizes new' do
+        @router.url(:new_singular_resource).must_equal 'https://test.com/stem/new'
+      end
+
+      it 'recognizes edit' do
+        @router.url(:edit_singular_resource).must_equal 'https://test.com/stem/edit'
+      end
+
+      it 'recognizes show' do
+        @router.url(:singular_resource).must_equal 'https://test.com/stem'
+      end
     end
   end
 

--- a/test/namespace_test.rb
+++ b/test/namespace_test.rb
@@ -244,6 +244,49 @@ describe Hanami::Router do
       end
     end
 
+    describe 'named RESTful resources' do
+      before do
+        @router.namespace 'vegetals' do
+          resources 'flowers', as: 'tulips'
+        end
+      end
+
+      it 'recognizes get index' do
+        @router.path(:vegetals_tulips).must_equal              '/vegetals/flowers'
+        @app.request('GET', '/vegetals/flowers', lint: true).body.must_equal         'Flowers::Index'
+      end
+
+      it 'recognizes get new' do
+        @router.path(:new_vegetals_tulip).must_equal          '/vegetals/flowers/new'
+        @app.request('GET', '/vegetals/flowers/new', lint: true).body.must_equal     'Flowers::New'
+      end
+
+      it 'recognizes post create' do
+        @router.path(:vegetals_tulips).must_equal                       '/vegetals/flowers'
+        @app.request('POST', '/vegetals/flowers', lint: true).body.must_equal        'Flowers::Create'
+      end
+
+      it 'recognizes get show' do
+        @router.path(:vegetals_tulip, id: 23).must_equal               '/vegetals/flowers/23'
+        @app.request('GET', '/vegetals/flowers/23', lint: true).body.must_equal      'Flowers::Show 23'
+      end
+
+      it 'recognizes get edit' do
+        @router.path(:edit_vegetals_tulip, id: 23).must_equal          '/vegetals/flowers/23/edit'
+        @app.request('GET', '/vegetals/flowers/23/edit', lint: true).body.must_equal 'Flowers::Edit 23'
+      end
+
+      it 'recognizes patch update' do
+        @router.path(:vegetals_tulip, id: 23).must_equal               '/vegetals/flowers/23'
+        @app.request('PATCH', '/vegetals/flowers/23', lint: true).body.must_equal    'Flowers::Update 23'
+      end
+
+      it 'recognizes delete destroy' do
+        @router.path(:vegetals_tulip, id: 23).must_equal               '/vegetals/flowers/23'
+        @app.request('DELETE', '/vegetals/flowers/23', lint: true).body.must_equal   'Flowers::Destroy 23'
+      end
+    end
+
     describe 'restful resource' do
       before do
         @router.namespace 'settings' do
@@ -334,6 +377,44 @@ describe Hanami::Router do
           exception = -> { @router.path(:edit_settings_profile) }.must_raise Hanami::Routing::InvalidRouteException
           exception.message.must_equal 'No route (path) could be generated for :edit_settings_profile - please check given arguments'
         end
+      end
+    end
+
+    describe 'named RESTful resource' do
+      before do
+        @router.namespace 'settings' do
+          resource 'avatar', as: 'icon'
+        end
+      end
+
+      it 'recognizes get new' do
+        @router.path(:new_settings_icon).must_equal      '/settings/avatar/new'
+        @app.request('GET', '/settings/avatar/new', lint: true).body.must_equal 'Avatar::New'
+      end
+
+      it 'recognizes post create' do
+        @router.path(:settings_icon).must_equal              '/settings/avatar'
+        @app.request('POST', '/settings/avatar', lint: true).body.must_equal 'Avatar::Create'
+      end
+
+      it 'recognizes get show' do
+        @router.path(:settings_icon).must_equal           '/settings/avatar'
+        @app.request('GET', '/settings/avatar', lint: true).body.must_equal 'Avatar::Show'
+      end
+
+      it 'recognizes get edit' do
+        @router.path(:edit_settings_icon).must_equal      '/settings/avatar/edit'
+        @app.request('GET', '/settings/avatar/edit', lint: true).body.must_equal 'Avatar::Edit'
+      end
+
+      it 'recognizes patch update' do
+        @router.path(:settings_icon).must_equal               '/settings/avatar'
+        @app.request('PATCH', '/settings/avatar', lint: true).body.must_equal 'Avatar::Update'
+      end
+
+      it 'recognizes delete destroy' do
+        @router.path(:settings_icon).must_equal                 '/settings/avatar'
+        @app.request('DELETE', '/settings/avatar', lint: true).body.must_equal 'Avatar::Destroy'
       end
     end
   end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -145,5 +145,36 @@ describe Hanami::Router do
         @app.request('GET', '/profile/new', lint: true).body.must_equal 'Keys::New'
       end
     end
+
+    describe ':as option' do
+      before do
+        @router.resource 'keyboard', as: 'piano' do
+          collection do
+            get 'search'
+          end
+
+          member do
+            get 'screenshot'
+          end
+        end
+      end
+
+      it 'recognizes the new name' do
+        @router.path(:piano).must_equal '/keyboard'
+        @router.path(:new_piano).must_equal '/keyboard/new'
+        @router.path(:edit_piano).must_equal '/keyboard/edit'
+        @router.path(:search_piano).must_equal '/keyboard/search'
+        @router.path(:screenshot_piano).must_equal '/keyboard/screenshot'
+      end
+
+      it 'does not recognize the resource name' do
+        e = Hanami::Routing::InvalidRouteException
+        -> { @router.path(:keyboard) }.must_raise e
+        -> { @router.path(:new_keyboard) }.must_raise e
+        -> { @router.path(:edit_keyboard) }.must_raise e
+        -> { @router.path(:search_keyboard) }.must_raise e
+        -> { @router.path(:screenshot_keyboard) }.must_raise e
+      end
+    end
   end
 end

--- a/test/resources_test.rb
+++ b/test/resources_test.rb
@@ -174,5 +174,38 @@ describe Hanami::Router do
         @app.request('GET', '/keyboards/8/screenshot', lint: true).body.must_equal 'Keys::Screenshot 8'
       end
     end
+
+    describe ':as option' do
+      before do
+        @router.resources 'keyboards', as: 'pianos' do
+          collection do
+            get 'search'
+          end
+
+          member do
+            get 'screenshot'
+          end
+        end
+      end
+
+      it 'recognizes the new name' do
+        @router.path(:pianos).must_equal '/keyboards'
+        @router.path(:piano, id: 3).must_equal '/keyboards/3'
+        @router.path(:new_piano).must_equal '/keyboards/new'
+        @router.path(:edit_piano, id: 5).must_equal '/keyboards/5/edit'
+        @router.path(:search_pianos).must_equal '/keyboards/search'
+        @router.path(:screenshot_piano, id: 8).must_equal '/keyboards/8/screenshot'
+      end
+
+      it 'does not recognize the resource name' do
+        e = Hanami::Routing::InvalidRouteException
+        -> { @router.path(:keyboards) }.must_raise e
+        -> { @router.path(:keyboard, id: 3) }.must_raise e
+        -> { @router.path(:new_keyboard) }.must_raise e
+        -> { @router.path(:edit_keyboard, id: 5) }.must_raise e
+        -> { @router.path(:search_keyboards) }.must_raise e
+        -> { @router.path(:screenshot_keyboard, id: 8) }.must_raise e
+      end
+    end
   end
 end

--- a/test/routing/routes_inspector_test.rb
+++ b/test/routing/routes_inspector_test.rb
@@ -209,12 +209,13 @@ describe Hanami::Routing::RoutesInspector do
         @router = Hanami::Router.new do
           get '/login', to: ->(env) { }, as: :login
         end
+        @proc_def_line = __LINE__ - 2
       end
 
       it 'inspects routes' do
         formatter     = "| %{methods} | %{name} | %{path} | %{endpoint} |\n"
         expectations  = [
-          %(| GET, HEAD | login | /login | #<Proc@#{ @path }:210 (lambda)> |)
+          %(| GET, HEAD | login | /login | #<Proc@#{ @path }:#{ @proc_def_line } (lambda)> |)
         ]
 
         actual = @router.inspector.to_s(formatter)

--- a/test/routing/routes_inspector_test.rb
+++ b/test/routing/routes_inspector_test.rb
@@ -160,6 +160,30 @@ describe Hanami::Routing::RoutesInspector do
       end
     end
 
+    describe 'named resource' do
+      before do
+        @router = Hanami::Router.new do
+          resource 'identity', as: 'user'
+        end
+      end
+
+      it 'inspects routes' do
+        expectations = [
+          %( new_user GET, HEAD  /identity/new                  Identity::New),
+          %(     user POST       /identity                      Identity::Create),
+          %(     user GET, HEAD  /identity                      Identity::Show),
+          %(edit_user GET, HEAD  /identity/edit                 Identity::Edit),
+          %(     user PATCH      /identity                      Identity::Update),
+          %(     user DELETE     /identity                      Identity::Destroy)
+        ]
+
+        actual = @router.inspector.to_s
+        expectations.each do |expectation|
+          actual.must_include(expectation)
+        end
+      end
+    end
+
     describe 'resources' do
       before do
         @router = Hanami::Router.new do
@@ -176,6 +200,31 @@ describe Hanami::Routing::RoutesInspector do
           %(edit_book GET, HEAD  /books/:id/edit                Books::Edit),
           %(     book PATCH      /books/:id                     Books::Update),
           %(     book DELETE     /books/:id                     Books::Destroy)
+        ]
+
+        actual = @router.inspector.to_s
+        expectations.each do |expectation|
+          actual.must_include(expectation)
+        end
+      end
+    end
+
+    describe 'named resources' do
+      before do
+        @router = Hanami::Router.new do
+          resources 'books', as: 'items'
+        end
+      end
+
+      it 'inspects routes' do
+        expectations = [
+         %(     items GET, HEAD  /books                         Books::Index),
+          %( new_item GET, HEAD  /books/new                     Books::New),
+         %(     items POST       /books                         Books::Create),
+          %(     item GET, HEAD  /books/:id                     Books::Show),
+          %(edit_item GET, HEAD  /books/:id/edit                Books::Edit),
+          %(     item PATCH      /books/:id                     Books::Update),
+          %(     item DELETE     /books/:id                     Books::Destroy)
         ]
 
         actual = @router.inspector.to_s


### PR DESCRIPTION
Scenario:

I am developing an application with Czech-only user interface and I want the URLs to be Czech, too. But the code is English, because it's beautiful and convenient. So I define routes like

```ruby
resources :kocky, controller: 'cats'
resources :psi, controller: 'dogs'
```

with Czech resource names mapping to English-named controllers.
The generated route names are not very satisfactory. Not only Czech and English are being mixed together, but furthermore the English pluralizer disfigures the Czech words:

```
             kockies GET, HEAD  /kocky                         Web::Controllers::Cats::Index 
           new_kocky GET, HEAD  /kocky/new                     Web::Controllers::Cats::New   
             kockies POST       /kocky                         Web::Controllers::Cats::Create
               kocky GET, HEAD  /kocky/:id                     Web::Controllers::Cats::Show  
          edit_kocky GET, HEAD  /kocky/:id/edit                Web::Controllers::Cats::Edit  
               kocky PATCH      /kocky/:id                     Web::Controllers::Cats::Update
               kocky DELETE     /kocky/:id                     Web::Controllers::Cats::Destroy
              psuses GET, HEAD  /psi                           Web::Controllers::Dogs::Index 
            new_psus GET, HEAD  /psi/new                       Web::Controllers::Dogs::New   
              psuses POST       /psi                           Web::Controllers::Dogs::Create
                psus GET, HEAD  /psi/:id                       Web::Controllers::Dogs::Show  
           edit_psus GET, HEAD  /psi/:id/edit                  Web::Controllers::Dogs::Edit  
                psus PATCH      /psi/:id                       Web::Controllers::Dogs::Update
                psus DELETE     /psi/:id                       Web::Controllers::Dogs::Destroy
```

I propose adding option `:as` (analogically to the non-RESTful routes) that will allow us to specify an alternative resource name to be used for internal route names instead of the public resource name used in URLs.

```ruby
resources :kocky, controller: 'cats', as: 'cats'
resources :psi, controller: 'dogs', as: 'dogs'
```