### PR TITLE
Fix issue with deep symbolize for router params

### DIFF
--- a/lib/hanami/routing/parsers.rb
+++ b/lib/hanami/routing/parsers.rb
@@ -58,7 +58,7 @@ module Hanami
 
       def _symbolize(body)
         if body.is_a?(Hash)
-          Utils::Hash.new(body).deep_dup.symbolize!.to_h
+          Utils::Hash.new(body).deep_dup.deep_symbolize!.to_h
         else
           { FALLBACK_KEY => body }
         end

--- a/test/routing/parsers_test.rb
+++ b/test/routing/parsers_test.rb
@@ -77,17 +77,17 @@ describe Hanami::Routing::Parsers do
       end
 
       describe 'and a JSON API request' do
-        let(:body)         { %({"attribute":"ok"}) }
+        let(:body)         { %({"data": {"attribute":"ok"}}) }
         let(:content_type) { 'application/vnd.api+json' }
 
         it "parses params from body" do
           result = @parsers.call(env)
-          result['router.params'].must_equal({attribute: "ok"})
+          result['router.params'].must_equal({data: {attribute: "ok"}})
         end
 
         it "stores parsed body" do
           result = @parsers.call(env)
-          result['router.parsed_body'].must_equal({'attribute' => "ok"})
+          result['router.parsed_body'].must_equal({'data' => {'attribute' => "ok"}})
         end
 
         describe 'with malformed json' do


### PR DESCRIPTION
Found that in hanami 1.0.0.beta1 construction like `params.get(:data, :attributes)` is not working. 
I found changes in Hanami::Utils for hash modifications. 
Now for deep symbolize need to use `#deep_symbolize!` instead of `#symbolize!`.
Also I fixed a test to check for deep params.