### PR TITLE
`Hanami::Router#recognize` must return a non routeable route when a lazy endpoint cannot be resolved

### DIFF
--- a/lib/hanami/routing/endpoint.rb
+++ b/lib/hanami/routing/endpoint.rb
@@ -45,6 +45,13 @@ module Hanami
           "#<#{ __getobj__.class }>"
         end
       end
+
+      # @since 1.0.0.beta2
+      # @api private
+      def routable?
+        !__getobj__.nil?
+      rescue ArgumentError
+      end
     end
 
     # Routing endpoint

--- a/lib/hanami/routing/recognized_route.rb
+++ b/lib/hanami/routing/recognized_route.rb
@@ -146,7 +146,7 @@ module Hanami
       #   puts router.recognize('/').routable?    # => true
       #   puts router.recognize('/foo').routable? # => false
       def routable?
-        !@endpoint.nil?
+        @endpoint&.routable?
       end
 
       private

--- a/test/recognize_test.rb
+++ b/test/recognize_test.rb
@@ -10,6 +10,7 @@ describe Hanami::Router do
         get '/rack_app',      to: RackMiddlewareInstanceMethod,       as: :rack_app
         get '/proc',          to: ->(_env) { [200, {}, ['OK']] },     as: :proc
         get '/resources/:id', to: ->(_env) { [200, {}, ['PARAMS']] }, as: :params
+        get '/missing',       to: "missing#index",                    as: :missing
       end
     end
 
@@ -111,6 +112,17 @@ describe Hanami::Router do
         route.params.must_equal({})
       end
 
+      it "returns not routeable result when the lazy endpoint doesn't correspond to an action" do
+        env   = Rack::MockRequest.env_for('/missing', method: :get)
+        route = @router.recognize(env)
+
+        assert !route.routable?, 'Expected route to NOT be routable'
+        route.action.must_be_nil
+        route.verb.must_equal   'GET'
+        route.path.must_equal   '/missing'
+        route.params.must_equal({})
+      end
+
       it 'raises error if #call is invoked for not routeable object when cannot recognize' do
         env   = Rack::MockRequest.env_for('/', method: :post)
         route = @router.recognize(env)
@@ -208,6 +220,16 @@ describe Hanami::Router do
         route.action.must_be_nil
         route.verb.must_equal    'POST'
         route.path.must_equal    '/'
+        route.params.must_equal({})
+      end
+
+      it "returns not routeable result when the lazy endpoint doesn't correspond to an action" do
+        route = @router.recognize('/missing')
+
+        assert !route.routable?, 'Expected route to NOT be routable'
+        route.action.must_be_nil
+        route.verb.must_equal   'GET'
+        route.path.must_equal   '/missing'
         route.params.must_equal({})
       end
 
@@ -331,6 +353,16 @@ describe Hanami::Router do
         route.action.must_be_nil
         route.verb.must_equal    'POST'
         route.path.must_equal    '/'
+        route.params.must_equal({})
+      end
+
+      it "returns not routeable result when the lazy endpoint doesn't correspond to an action" do
+        route = @router.recognize(:missing)
+
+        assert !route.routable?, 'Expected route to NOT be routable'
+        route.action.must_be_nil
+        route.verb.must_equal   'GET'
+        route.path.must_equal   '/missing'
         route.params.must_equal({})
       end
 


### PR DESCRIPTION
This is a fix for a problem with `Hanami::Router#recognize`. When a _lazy endpoint_ cannot be resolved, it should return a non-routeable object instead of raising `ArgumentError`.

Given the following routes:

```ruby
router = Hanami::Router.new do
  get '/books', to: 'books#index'
end
```

When `"books#index"` cannot be immediately associated to an action, the router instantiate a _lazy endpoint_, which will defer the resolution on the first request.

In case the action wasn't defined at all, the router used to raise a cryptic error.

### Before

```ruby
route = router.recognize("/books")
route.routable? # => true
route.action # => ArgumentError: not delegated
```

### After

```ruby
route = router.recognize("/books")
route.routable? # => false
route.action # => nil
```