### PR TITLE
Fix call to HTTP method named `unklink`

### DIFF
--- a/spec/integration/hanami/router/mount_spec.rb
+++ b/spec/integration/hanami/router/mount_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hanami::Router do
     @app = Rack::MockRequest.new(@router)
   end
 
-  %w[get post delete put patch trace options link unklink].each do |verb|
+  %w[get post delete put patch trace options link unlink].each do |verb|
     it "accepts #{verb} for a class endpoint" do
       expect(@app.request(verb.upcase, '/backend', lint: true).body). to eq('home')
     end

--- a/spec/integration/hanami/router/namespace_spec.rb
+++ b/spec/integration/hanami/router/namespace_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe Hanami::Router do
         end
       end
 
-      [ 'get', 'post', 'delete', 'put', 'patch', 'trace', 'options', 'link', 'unklink' ].each do |verb|
+      [ 'get', 'post', 'delete', 'put', 'patch', 'trace', 'options', 'link', 'unlink' ].each do |verb|
         it "accepts #{ verb } for a namespaced mount" do
           expect(@app.request(verb.upcase, '/api/backend', lint: true).body).to eq('home')
         end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -70,8 +70,13 @@ end # Api
 
 module Backend
   class App
+    VERBS = %w[GET POST DELETE PUT PATCH TRACE OPTIONS LINK UNLINK]
     def self.call(env)
-      [200, {}, ['home']]
+      if VERBS.include? env['REQUEST_METHOD']
+        [200, {}, ['home']]
+      else
+        [405, {}, ['Method Not Allowed']]
+      end
     end
   end
 end # Backend


### PR DESCRIPTION
Hi,

This might be an unnecessary fix as the router seems to accept any HTTP method and forward it gracefully to the back-end, but just in case, this ensures that the correct methods are being tested by the specs. It does not ensure, however, that all methods are tested.

This could be fixed by having a single source of truth for the list of HTTP methods, but I'm deep into unknown territory and don't know whether it would make sense, and if it did, where it should be stored or from what it should be extracted from.