### PR TITLE
Single tier routing for Hanami

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,5 +2,8 @@
 # alphabetically
 inherit_from:
   - https://raw.githubusercontent.com/hanami/devtools/master/.rubocop-unstable.yml
+Metrics/ParameterLists:
+  Exclude:
+    - "lib/hanami/router.rb"
 Performance/RegexpMatch:
   Enabled: false

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -74,6 +74,7 @@ module Hanami
   #   end
   #
   #   # All the requests starting with "/api" will be forwarded to Api::App
+  #
   class Router # rubocop:disable Metrics/ClassLength
     # This error is raised when <tt>#call</tt> is invoked on a non-routable
     # recognized route.
@@ -234,7 +235,6 @@ module Hanami
     #
     #   [200, {}, ["{:name=>\"LG\",:id=>\"1\"}"]]
     #
-    # rubocop:disable Metrics/ParameterLists
     # rubocop:disable Metrics/MethodLength
     def initialize(scheme: "http", host: "localhost", port: 80, prefix: "", namespace: nil, parsers: [], force_ssl: false, not_found: NOT_FOUND, not_allowed: NOT_ALLOWED, &blk)
       @routes      = []
@@ -250,7 +250,6 @@ module Hanami
       freeze
     end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/ParameterLists
 
     # Freeze the router
     #
@@ -406,8 +405,8 @@ module Hanami
     #
     #    # It will map to Flowers::Index.new, which is the
     #    # Hanami::Controller convention.
-    def get(path, to: nil, as: nil, **constraints, &blk)
-      add_route(GET, path, to, as, constraints, &blk)
+    def get(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
+      add_route(GET, path, to, as, namespace, constraints, &blk)
     end
 
     # Defines a route that accepts a POST request for the given path.
@@ -425,8 +424,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def post(path, to: nil, as: nil, **constraints, &blk)
-      add_route(POST, path, to, as, constraints, &blk)
+    def post(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
+      add_route(POST, path, to, as, namespace, constraints, &blk)
     end
 
     # Defines a route that accepts a PUT request for the given path.
@@ -444,8 +443,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def put(path, to: nil, as: nil, **constraints, &blk)
-      add_route(PUT, path, to, as, constraints, &blk)
+    def put(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
+      add_route(PUT, path, to, as, namespace, constraints, &blk)
     end
 
     # Defines a route that accepts a PATCH request for the given path.
@@ -463,8 +462,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def patch(path, to: nil, as: nil, **constraints, &blk)
-      add_route(PATCH, path, to, as, constraints, &blk)
+    def patch(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
+      add_route(PATCH, path, to, as, namespace, constraints, &blk)
     end
 
     # Defines a route that accepts a DELETE request for the given path.
@@ -482,8 +481,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def delete(path, to: nil, as: nil, **constraints, &blk)
-      add_route(DELETE, path, to, as, constraints, &blk)
+    def delete(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
+      add_route(DELETE, path, to, as, namespace, constraints, &blk)
     end
 
     # Defines a route that accepts a TRACE request for the given path.
@@ -501,8 +500,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def trace(path, to: nil, as: nil, **constraints, &blk)
-      add_route(TRACE, path, to, as, constraints, &blk)
+    def trace(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
+      add_route(TRACE, path, to, as, namespace, constraints, &blk)
     end
 
     # Defines a route that accepts a LINK request for the given path.
@@ -520,8 +519,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.8.0
-    def link(path, to: nil, as: nil, **constraints, &blk)
-      add_route(LINK, path, to, as, constraints, &blk)
+    def link(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
+      add_route(LINK, path, to, as, namespace, constraints, &blk)
     end
 
     # Defines a route that accepts an UNLINK request for the given path.
@@ -539,8 +538,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.8.0
-    def unlink(path, to: nil, as: nil, **constraints, &blk)
-      add_route(UNLINK, path, to, as, constraints, &blk)
+    def unlink(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
+      add_route(UNLINK, path, to, as, namespace, constraints, &blk)
     end
 
     # Defines a route that accepts a OPTIONS request for the given path.
@@ -558,8 +557,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def options(path, to: nil, as: nil, **constraints, &blk)
-      add_route(OPTIONS, path, to, as, constraints, &blk)
+    def options(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
+      add_route(OPTIONS, path, to, as, namespace, constraints, &blk)
     end
 
     # Defines a root route (a GET route for '/')
@@ -588,8 +587,8 @@ module Hanami
     #
     #   router.path(:root) # => "/"
     #   router.url(:root)  # => "https://hanamirb.org/"
-    def root(to: nil, &blk)
-      add_route(GET, ROOT_PATH, to, :root, &blk)
+    def root(to: nil, as: :root, prefix: Utils::PathPrefix.new, namespace: nil, &blk)
+      add_route(GET, prefix.join(ROOT_PATH), to, as, namespace, &blk)
     end
 
     # Defines an HTTP redirect
@@ -657,8 +656,31 @@ module Hanami
     #       end
     #     end
     #   end
-    def prefix(path, &blk)
-      Routing::Prefix.new(self, path, &blk)
+    def prefix(path, namespace: nil, &blk)
+      Routing::Prefix.new(self, path, namespace, &blk)
+    end
+
+    # Defines a scope for routes.
+    #
+    # A scope is a combination of a path prefix and a Ruby namespace.
+    #
+    # @param prefix [String] the path prefix
+    # @param namespace [Module] the Ruby namespace where to lookup endpoints
+    # @param blk [Proc] the routes definition block
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @example
+    #   require "hanami/router"
+    #
+    #   Hanami::Router.new do
+    #     scope "/admin", namespace: Admin::Controllers do
+    #       root to: "home#index"
+    #     end
+    #   end
+    def scope(prefix, namespace:, &blk)
+      Routing::Scope.new(self, prefix, namespace, &blk)
     end
 
     # Defines a set of named routes for a single RESTful resource.
@@ -1313,11 +1335,11 @@ module Hanami
       end
     end
 
-    def add_route(verb, path, to, as = nil, constraints = {}, &blk) # rubocop:disable Metrics/ParameterLists
+    def add_route(verb, path, to, as = nil, namespace = nil, constraints = {}, &blk)
       to ||= blk
 
       path     = path.to_s
-      endpoint = Routing::Endpoint.find(to, @namespace)
+      endpoint = Routing::Endpoint.find(to, namespace || @namespace)
       route    = Routing::Route.new(verb_for(verb), @prefix.join(path).to_s, endpoint, constraints)
 
       @routes.push(route)

--- a/lib/hanami/routing.rb
+++ b/lib/hanami/routing.rb
@@ -185,6 +185,7 @@ module Hanami
 
     require "hanami/routing/endpoint"
     require "hanami/routing/prefix"
+    require "hanami/routing/scope"
     require "hanami/routing/resource"
     require "hanami/routing/resources"
     require "hanami/routing/force_ssl"

--- a/lib/hanami/routing/prefix.rb
+++ b/lib/hanami/routing/prefix.rb
@@ -15,9 +15,10 @@ module Hanami
     class Prefix < SimpleDelegator
       # @api private
       # @since x.x.x
-      def initialize(router, path, &blk)
-        @router = router
-        @path   = Utils::PathPrefix.new(path)
+      def initialize(router, path, namespace, &blk)
+        @router    = router
+        @namespace = namespace
+        @path      = Utils::PathPrefix.new(path)
         __setobj__(@router)
         instance_eval(&blk)
       end
@@ -25,55 +26,55 @@ module Hanami
       # @api private
       # @since x.x.x
       def get(path, options = {}, &endpoint)
-        super(@path.join(path), options, &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def post(path, options = {}, &endpoint)
-        super(@path.join(path), options, &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def put(path, options = {}, &endpoint)
-        super(@path.join(path), options, &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def patch(path, options = {}, &endpoint)
-        super(@path.join(path), options, &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def delete(path, options = {}, &endpoint)
-        super(@path.join(path), options, &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def trace(path, options = {}, &endpoint)
-        super(@path.join(path), options, &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def options(path, options = {}, &endpoint)
-        super(@path.join(path), options, &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def resource(name, options = {})
-        super name, options.merge(prefix: @path.relative_join(options[:prefix]))
+        super(name, options.merge(prefix: @path.relative_join(options[:prefix]), namespace: @namespace))
       end
 
       # @api private
       # @since x.x.x
       def resources(name, options = {})
-        super name, options.merge(prefix: @path.relative_join(options[:prefix]))
+        super(name, options.merge(prefix: @path.relative_join(options[:prefix]), namespace: @namespace))
       end
 
       # @api private
@@ -93,7 +94,7 @@ module Hanami
       # @api private
       # @since x.x.x
       def prefix(path, &blk)
-        self.class.new(self, path, &blk)
+        self.class.new(self, path, @namespace, &blk)
       end
     end
   end

--- a/lib/hanami/routing/resource/action.rb
+++ b/lib/hanami/routing/resource/action.rb
@@ -84,7 +84,7 @@ module Hanami
         #
         # @since 0.1.0
         def generate(&blk)
-          @router.send verb, path, to: endpoint, as: as
+          @router.send verb, path, to: endpoint, as: as, namespace: namespace
           instance_eval(&blk) if block_given?
         end
 
@@ -113,6 +113,14 @@ module Hanami
         # @since x.x.x
         def prefix
           @prefix ||= Utils::PathPrefix.new(@options[:prefix])
+        end
+
+        # Namespace
+        #
+        # @api private
+        # @since x.x.x
+        def namespace
+          @namespace ||= @options[:namespace]
         end
 
         # Load a subclass, according to the given action name
@@ -298,7 +306,7 @@ module Hanami
           action_name = Utils::PathPrefix.new(args.first).relative_join(nil)
 
           @router.__send__ verb, path(action_name),
-                           to: endpoint(action_name), as: as(action_name)
+                           to: endpoint(action_name), as: as(action_name), namespace: namespace
         end
 
         private

--- a/lib/hanami/routing/scope.rb
+++ b/lib/hanami/routing/scope.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "delegate"
+require "hanami/utils/path_prefix"
+
+module Hanami
+  module Routing
+    # Prefix for routes.
+    # Implementation of Hanami::Router#prefix
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Hanami::Router#prefix
+    class Scope < SimpleDelegator
+      # @api private
+      # @since x.x.x
+      def initialize(router, prefix, namespace, &blk)
+        @router    = router
+        @namespace = namespace
+        @prefix    = Utils::PathPrefix.new(prefix)
+        __setobj__(@router)
+        instance_eval(&blk)
+      end
+
+      def root(to:, as: :root, **, &blk)
+        super(to: to, as: route_name(as), prefix: @prefix, namespace: @namespace, &blk)
+      end
+
+      # @api private
+      # @since x.x.x
+      def get(path, as: nil, **options, &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+      end
+
+      # @api private
+      # @since x.x.x
+      def post(path, as: nil, **options, &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+      end
+
+      # @api private
+      # @since x.x.x
+      def put(path, as: nil, **options, &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+      end
+
+      # @api private
+      # @since x.x.x
+      def patch(path, as: nil, **options, &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+      end
+
+      # @api private
+      # @since x.x.x
+      def delete(path, as: nil, **options, &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+      end
+
+      # @api private
+      # @since x.x.x
+      def trace(path, as: nil, **options, &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+      end
+
+      # @api private
+      # @since x.x.x
+      def options(path, as: nil, **options, &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+      end
+
+      # @api private
+      # @since x.x.x
+      def resource(name, options = {})
+        super(name, options.merge(prefix: @prefix.relative_join(options[:prefix]), namespace: @namespace))
+      end
+
+      # @api private
+      # @since x.x.x
+      def resources(name, options = {})
+        super(name, options.merge(prefix: @prefix.relative_join(options[:prefix]), namespace: @namespace))
+      end
+
+      # @api private
+      # @since x.x.x
+      def redirect(path, options = {}, &endpoint)
+        super(@prefix.join(path), options.merge(to: @prefix.join(options[:to])), &endpoint)
+      end
+
+      # @api private
+      # @since x.x.x
+      def mount(app, options)
+        super(app, options.merge(at: @prefix.join(options[:at])))
+      end
+
+      # @api private
+      # @since x.x.x
+      def prefix(path, &blk)
+        super(@prefix.join(path), namespace: @namespace, &blk)
+      end
+
+      private
+
+      ROUTE_NAME_SEPARATOR = "_"
+
+      def route_name(as)
+        @prefix.relative_join(as, ROUTE_NAME_SEPARATOR).to_sym unless as.nil?
+      end
+    end
+  end
+end

--- a/spec/integration/hanami/router/scope_spec.rb
+++ b/spec/integration/hanami/router/scope_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Router do
+  describe "#scope" do
+    let(:app) { Rack::MockRequest.new(router) }
+    let(:router) do
+      described_class.new do
+        scope "/admin", namespace: Admin::Controllers do
+          root to: "home#index"
+
+          get  "/signin", to: "sessions#new", as: :signin
+          post "/signin", to: "sessions#create"
+
+          resource  :settings, only: [:show]
+          resources :users,    only: [:show]
+
+          prefix "/t" do
+            get "/:name", to: "topics#show"
+          end
+
+          redirect "/dashboard", to: "/"
+          mount Backend::App, at: "/backend"
+        end
+
+        scope "/", namespace: Web::Controllers do
+          root to: "home#index"
+
+          get  "/signin", to: "sessions#new", as: :signin
+          post "/signin", to: "sessions#create"
+
+          resource  :settings, only: [:show]
+          resources :users,    only: [:show]
+
+          prefix "/t" do
+            get "/:name", to: "topics#show"
+          end
+
+          redirect "/dashboard", to: "/"
+          mount Backend::App, at: "/backend"
+        end
+      end
+    end
+
+    it "recognizes root path" do
+      expect(app.request("GET", "/", lint: true).body).to include("Web::Controllers::Home::Index")
+      expect(app.request("GET", "/admin", lint: true).body).to include("Admin::Controllers::Home::Index")
+    end
+
+    it "recognizes get path" do
+      expect(app.request("GET", "/signin", lint: true).body).to include("Web::Controllers::Sessions::New")
+      expect(app.request("GET", "/admin/signin", lint: true).body).to include("Admin::Controllers::Sessions::New")
+    end
+
+    it "recognizes post path" do
+      expect(app.request("POST", "/signin", lint: true).body).to include("Web::Controllers::Sessions::Create")
+      expect(app.request("POST", "/admin/signin", lint: true).body).to include("Admin::Controllers::Sessions::Create")
+    end
+
+    it "recognizes resource" do
+      expect(app.request("GET", "/settings", lint: true).body).to include("Web::Controllers::Settings::Show")
+      expect(app.request("GET", "/admin/settings", lint: true).body).to include("Admin::Controllers::Settings::Show")
+    end
+
+    it "recognizes resources" do
+      expect(app.request("GET", "/users/23", lint: true).body).to include("Web::Controllers::Users::Show")
+      expect(app.request("GET", "/admin/users/23", lint: true).body).to include("Admin::Controllers::Users::Show")
+    end
+
+    it "recognizes prefixed actions" do
+      expect(app.request("GET", "/t/ruby", lint: true).body).to include("Web::Controllers::Topics::Show")
+      expect(app.request("GET", "/admin/t/ruby", lint: true).body).to include("Admin::Controllers::Topics::Show")
+    end
+
+    it "defines redirect" do
+      expect(app.request("GET", "/dashboard", lint: true).headers["Location"]).to eq("/")
+      expect(app.request("GET", "/admin/dashboard", lint: true).headers["Location"]).to eq("/admin")
+    end
+
+    context "mount" do
+      RSpec::Support::HTTP.verbs.each do |verb|
+        it "accepts #{verb} for a mounted app" do
+          expect(app.request(verb.upcase, "/backend", lint: true).body).to eq(body_for("home", verb))
+          expect(app.request(verb.upcase, "/admin/backend", lint: true).body).to eq(body_for("home", verb))
+        end
+      end
+    end
+
+    context "named paths" do
+      it "recognizes root path" do
+        expect(router.path(:root)).to eq("/")
+        expect(router.path(:admin_root)).to eq("/admin")
+      end
+
+      it "recognizes custom named path" do
+        expect(router.path(:signin)).to eq("/signin")
+        expect(router.path(:admin_signin)).to eq("/admin/signin")
+      end
+
+      it "recognizes resource" do
+        expect(router.path(:setting)).to eq("/settings")
+        expect(router.path(:admin_setting)).to eq("/admin/settings")
+      end
+
+      it "recognizes resources" do
+        expect(router.path(:user, id: 23)).to eq("/users/23")
+        expect(router.path(:admin_user, id: 23)).to eq("/admin/users/23")
+      end
+
+      xit "recognizes prefixed paths" do
+        expect(router.path(:topic, name: "ruby")).to eq("/t/ruby")
+        expect(router.path(:admin_topic, id: "ruby")).to eq("/admin/t/ruby")
+      end
+    end
+  end
+end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -48,8 +48,96 @@ module Web
         end
       end
     end # Dashboard
+
+    module Sessions
+      class New
+        def call(_params)
+          [200, {}, ["Hello from Web::Controllers::Sessions::New"]]
+        end
+      end
+
+      class Create
+        def call(_params)
+          [200, {}, ["Hello from Web::Controllers::Sessions::Create"]]
+        end
+      end
+    end
+
+    module Settings
+      class Show
+        def call(_params)
+          [200, {}, ["Hello from Web::Controllers::Settings::Show"]]
+        end
+      end
+    end
+
+    module Users
+      class Show
+        def call(_params)
+          [200, {}, ["Hello from Web::Controllers::Users::Show"]]
+        end
+      end
+    end
+
+    module Topics
+      class Show
+        def call(_params)
+          [200, {}, ["Hello from Web::Controllers::Topics::Show"]]
+        end
+      end
+    end
   end
 end # Web
+
+module Admin
+  module Controllers
+    module Home
+      class Index
+        def call(_params)
+          [200, {}, ["Hello from Admin::Controllers::Home::Index"]]
+        end
+      end
+    end # Home
+
+    module Sessions
+      class New
+        def call(_params)
+          [200, {}, ["Hello from Admin::Controllers::Sessions::New"]]
+        end
+      end
+
+      class Create
+        def call(_params)
+          [200, {}, ["Hello from Admin::Controllers::Sessions::Create"]]
+        end
+      end
+    end
+
+    module Settings
+      class Show
+        def call(_params)
+          [200, {}, ["Hello from Admin::Controllers::Settings::Show"]]
+        end
+      end
+    end
+
+    module Users
+      class Show
+        def call(_params)
+          [200, {}, ["Hello from Admin::Controllers::Users::Show"]]
+        end
+      end
+    end
+
+    module Topics
+      class Show
+        def call(_params)
+          [200, {}, ["Hello from Admin::Controllers::Topics::Show"]]
+        end
+      end
+    end
+  end
+end
 
 module Front
   class App


### PR DESCRIPTION
**TL;DR:** In Hanami 1.x series we have inefficient routing, we want to make it efficient in 2.x.

---

## Existing

We call the existing Hanami routing a **two-tier routing**. The first tier is for the Hanami project (let's say a `bookshelf` product), and the second tier is within a single app (`Web`, `Admin`, etc..). Imagine this as an "umbrella routing".

### Project tier

When a request to `/admin/people/23` comes in, the first tier (project router) decides which app should be routed to. Let's see this practically:

```ruby
# config/environment.rb
Hanami.configure do
  mount Admin::Application, at: "/admin"
  mount Web::Application, at: "/"
  # ...
end
```

Behind the code above, there is an `Hanami::Router` instance. The main responsibility of this router is to choose the right app, or to return a `404`.

### Application tier

Following the example above, the project tier (router) invokes `Admin::Application#call`, passing the Rack env. At this point, the router for this app (app tier) is responsible to route the request to the action associated to `/people/23` (a subpath of the original request).

Again, if there is an action, it gets invoked, or it returns a `404`.

### Recap

An Hanami project has `n+1` `Hanami::Router` instances, where `n` is the number of apps (`Web`, `Admin`, etc..), plus the project itself (the root of the umbrella).

---

## Proposal

We can use only one `Hanami::Router` at the project level.

When we mount an application, instead of instantiating its own `Hanami::Router`, we can take the routes defined for that app and add to the project router.

With this technique when a request `/admin/people/23` is coming in, the project router is able to pick directly the corresponding action (or `404`), without delegating to a second tier.

This saves us memory: `1` instance of `Hanami::Router` per project, instead of `n+1`. It also saves runtime CPU/memory because it **doesn't** need to go to the routing system twice (one to pick the app, one to pick the action).

### Technical details

This introduces a new API private method: `Hanami::Router#scope` which accepts a path prefix, a Ruby namespace where to lookup for actions and a block that defines the routes.

**Please notice** that this doesn't change how people will mount their apps in Hanami project, the change is happening under the hood.

There is a bit of code repetition between `Hanami::Routing::Prefix` and `Hanami::Routing::Scope` (introduced by this PR). I'm **not** DRYing it for now.

---

Ref https://github.com/hanami/router/pull/156