### PR TITLE
Scope configuration

### DIFF
--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -236,16 +236,17 @@ module Hanami
     #   [200, {}, ["{:name=>\"LG\",:id=>\"1\"}"]]
     #
     # rubocop:disable Metrics/MethodLength
-    def initialize(scheme: "http", host: "localhost", port: 80, prefix: "", namespace: nil, parsers: [], force_ssl: false, not_found: NOT_FOUND, not_allowed: NOT_ALLOWED, &blk)
-      @routes      = []
-      @named       = {}
-      @namespace   = namespace
-      @base        = Routing::Uri.build(scheme: scheme, host: host, port: port)
-      @prefix      = Utils::PathPrefix.new(prefix)
-      @parsers     = Routing::Parsers.new(parsers)
-      @force_ssl   = Hanami::Routing::ForceSsl.new(force_ssl, host: host, port: port)
-      @not_found   = not_found
-      @not_allowed = not_allowed
+    def initialize(scheme: "http", host: "localhost", port: 80, prefix: "", namespace: nil, configuration: nil, parsers: [], force_ssl: false, not_found: NOT_FOUND, not_allowed: NOT_ALLOWED, &blk)
+      @routes        = []
+      @named         = {}
+      @namespace     = namespace
+      @configuration = configuration
+      @base          = Routing::Uri.build(scheme: scheme, host: host, port: port)
+      @prefix        = Utils::PathPrefix.new(prefix)
+      @parsers       = Routing::Parsers.new(parsers)
+      @force_ssl     = Hanami::Routing::ForceSsl.new(force_ssl, host: host, port: port)
+      @not_found     = not_found
+      @not_allowed   = not_allowed
       instance_eval(&blk) unless blk.nil?
       freeze
     end
@@ -405,8 +406,8 @@ module Hanami
     #
     #    # It will map to Flowers::Index.new, which is the
     #    # Hanami::Controller convention.
-    def get(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
-      add_route(GET, path, to, as, namespace, constraints, &blk)
+    def get(path, to: nil, as: nil, namespace: nil, configuration: nil, **constraints, &blk)
+      add_route(GET, path, to, as, namespace, configuration, constraints, &blk)
     end
 
     # Defines a route that accepts a POST request for the given path.
@@ -424,8 +425,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def post(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
-      add_route(POST, path, to, as, namespace, constraints, &blk)
+    def post(path, to: nil, as: nil, namespace: nil, configuration: nil, **constraints, &blk)
+      add_route(POST, path, to, as, namespace, configuration, constraints, &blk)
     end
 
     # Defines a route that accepts a PUT request for the given path.
@@ -443,8 +444,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def put(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
-      add_route(PUT, path, to, as, namespace, constraints, &blk)
+    def put(path, to: nil, as: nil, namespace: nil, configuration: nil, **constraints, &blk)
+      add_route(PUT, path, to, as, namespace, configuration, constraints, &blk)
     end
 
     # Defines a route that accepts a PATCH request for the given path.
@@ -462,8 +463,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def patch(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
-      add_route(PATCH, path, to, as, namespace, constraints, &blk)
+    def patch(path, to: nil, as: nil, namespace: nil, configuration: nil, **constraints, &blk)
+      add_route(PATCH, path, to, as, namespace, configuration, constraints, &blk)
     end
 
     # Defines a route that accepts a DELETE request for the given path.
@@ -481,8 +482,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def delete(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
-      add_route(DELETE, path, to, as, namespace, constraints, &blk)
+    def delete(path, to: nil, as: nil, namespace: nil, configuration: nil, **constraints, &blk)
+      add_route(DELETE, path, to, as, namespace, configuration, constraints, &blk)
     end
 
     # Defines a route that accepts a TRACE request for the given path.
@@ -500,8 +501,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def trace(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
-      add_route(TRACE, path, to, as, namespace, constraints, &blk)
+    def trace(path, to: nil, as: nil, namespace: nil, configuration: nil, **constraints, &blk)
+      add_route(TRACE, path, to, as, namespace, configuration, constraints, &blk)
     end
 
     # Defines a route that accepts a LINK request for the given path.
@@ -519,8 +520,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.8.0
-    def link(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
-      add_route(LINK, path, to, as, namespace, constraints, &blk)
+    def link(path, to: nil, as: nil, namespace: nil, configuration: nil, **constraints, &blk)
+      add_route(LINK, path, to, as, namespace, configuration, constraints, &blk)
     end
 
     # Defines a route that accepts an UNLINK request for the given path.
@@ -538,8 +539,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.8.0
-    def unlink(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
-      add_route(UNLINK, path, to, as, namespace, constraints, &blk)
+    def unlink(path, to: nil, as: nil, namespace: nil, configuration: nil, **constraints, &blk)
+      add_route(UNLINK, path, to, as, namespace, configuration, constraints, &blk)
     end
 
     # Defines a route that accepts a OPTIONS request for the given path.
@@ -557,8 +558,8 @@ module Hanami
     # @see Hanami::Router#get
     #
     # @since 0.1.0
-    def options(path, to: nil, as: nil, namespace: nil, **constraints, &blk)
-      add_route(OPTIONS, path, to, as, namespace, constraints, &blk)
+    def options(path, to: nil, as: nil, namespace: nil, configuration: nil, **constraints, &blk)
+      add_route(OPTIONS, path, to, as, namespace, configuration, constraints, &blk)
     end
 
     # Defines a root route (a GET route for '/')
@@ -587,8 +588,8 @@ module Hanami
     #
     #   router.path(:root) # => "/"
     #   router.url(:root)  # => "https://hanamirb.org/"
-    def root(to: nil, as: :root, prefix: Utils::PathPrefix.new, namespace: nil, &blk)
-      add_route(GET, prefix.join(ROOT_PATH), to, as, namespace, &blk)
+    def root(to: nil, as: :root, prefix: Utils::PathPrefix.new, namespace: nil, configuration: nil, &blk)
+      add_route(GET, prefix.join(ROOT_PATH), to, as, namespace, configuration, &blk)
     end
 
     # Defines an HTTP redirect
@@ -656,8 +657,8 @@ module Hanami
     #       end
     #     end
     #   end
-    def prefix(path, namespace: nil, &blk)
-      Routing::Prefix.new(self, path, namespace, &blk)
+    def prefix(path, namespace: nil, configuration: nil, &blk)
+      Routing::Prefix.new(self, path, namespace, configuration, &blk)
     end
 
     # Defines a scope for routes.
@@ -666,6 +667,8 @@ module Hanami
     #
     # @param prefix [String] the path prefix
     # @param namespace [Module] the Ruby namespace where to lookup endpoints
+    # @param configuration [Hanami::Controller::Configuration] the action
+    #   configuration
     # @param blk [Proc] the routes definition block
     #
     # @since x.x.x
@@ -673,14 +676,17 @@ module Hanami
     #
     # @example
     #   require "hanami/router"
+    #   require "hanami/controller"
+    #
+    #   configuration = Hanami::Controller::Configuration.new
     #
     #   Hanami::Router.new do
-    #     scope "/admin", namespace: Admin::Controllers do
+    #     scope "/admin", namespace: Admin::Controllers, configuration: configuration do
     #       root to: "home#index"
     #     end
     #   end
-    def scope(prefix, namespace:, &blk)
-      Routing::Scope.new(self, prefix, namespace, &blk)
+    def scope(prefix, namespace:, configuration:, &blk)
+      Routing::Scope.new(self, prefix, namespace, configuration, &blk)
     end
 
     # Defines a set of named routes for a single RESTful resource.
@@ -1299,6 +1305,8 @@ module Hanami
 
     BODY = 2
 
+    attr_reader :configuration
+
     # Application
     #
     # @since x.x.x
@@ -1335,11 +1343,12 @@ module Hanami
       end
     end
 
-    def add_route(verb, path, to, as = nil, namespace = nil, constraints = {}, &blk)
-      to ||= blk
+    def add_route(verb, path, to, as = nil, namespace = nil, config = nil, constraints = {}, &blk)
+      to     ||= blk
+      config ||= configuration
 
       path     = path.to_s
-      endpoint = Routing::Endpoint.find(to, namespace || @namespace)
+      endpoint = Routing::Endpoint.find(to, namespace || @namespace, config)
       route    = Routing::Route.new(verb_for(verb), @prefix.join(path).to_s, endpoint, constraints)
 
       @routes.push(route)

--- a/lib/hanami/routing/prefix.rb
+++ b/lib/hanami/routing/prefix.rb
@@ -15,10 +15,11 @@ module Hanami
     class Prefix < SimpleDelegator
       # @api private
       # @since x.x.x
-      def initialize(router, path, namespace, &blk)
-        @router    = router
-        @namespace = namespace
-        @path      = Utils::PathPrefix.new(path)
+      def initialize(router, path, namespace, configuration, &blk)
+        @router        = router
+        @namespace     = namespace
+        @configuration = configuration
+        @path          = Utils::PathPrefix.new(path)
         __setobj__(@router)
         instance_eval(&blk)
       end
@@ -26,55 +27,55 @@ module Hanami
       # @api private
       # @since x.x.x
       def get(path, options = {}, &endpoint)
-        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def post(path, options = {}, &endpoint)
-        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def put(path, options = {}, &endpoint)
-        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def patch(path, options = {}, &endpoint)
-        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def delete(path, options = {}, &endpoint)
-        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def trace(path, options = {}, &endpoint)
-        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def options(path, options = {}, &endpoint)
-        super(@path.join(path), options.merge(namespace: @namespace), &endpoint)
+        super(@path.join(path), options.merge(namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def resource(name, options = {})
-        super(name, options.merge(prefix: @path.relative_join(options[:prefix]), namespace: @namespace))
+        super(name, options.merge(prefix: @path.relative_join(options[:prefix]), namespace: @namespace, configuration: @configuration))
       end
 
       # @api private
       # @since x.x.x
       def resources(name, options = {})
-        super(name, options.merge(prefix: @path.relative_join(options[:prefix]), namespace: @namespace))
+        super(name, options.merge(prefix: @path.relative_join(options[:prefix]), namespace: @namespace, configuration: @configuration))
       end
 
       # @api private
@@ -94,7 +95,7 @@ module Hanami
       # @api private
       # @since x.x.x
       def prefix(path, &blk)
-        self.class.new(self, path, @namespace, &blk)
+        self.class.new(self, path, @namespace, @configuration, &blk)
       end
     end
   end

--- a/lib/hanami/routing/resource/action.rb
+++ b/lib/hanami/routing/resource/action.rb
@@ -84,7 +84,7 @@ module Hanami
         #
         # @since 0.1.0
         def generate(&blk)
-          @router.send verb, path, to: endpoint, as: as, namespace: namespace
+          @router.send verb, path, to: endpoint, as: as, namespace: namespace, configuration: configuration
           instance_eval(&blk) if block_given?
         end
 
@@ -121,6 +121,14 @@ module Hanami
         # @since x.x.x
         def namespace
           @namespace ||= @options[:namespace]
+        end
+
+        # Configuration
+        #
+        # @api private
+        # @since x.x.x
+        def configuration
+          @configuration ||= @options[:configuration]
         end
 
         # Load a subclass, according to the given action name
@@ -306,7 +314,8 @@ module Hanami
           action_name = Utils::PathPrefix.new(args.first).relative_join(nil)
 
           @router.__send__ verb, path(action_name),
-                           to: endpoint(action_name), as: as(action_name), namespace: namespace
+                           to: endpoint(action_name), as: as(action_name),
+                           namespace: namespace, configuration: configuration
         end
 
         private

--- a/lib/hanami/routing/scope.rb
+++ b/lib/hanami/routing/scope.rb
@@ -15,70 +15,71 @@ module Hanami
     class Scope < SimpleDelegator
       # @api private
       # @since x.x.x
-      def initialize(router, prefix, namespace, &blk)
-        @router    = router
-        @namespace = namespace
-        @prefix    = Utils::PathPrefix.new(prefix)
+      def initialize(router, prefix, namespace, configuration, &blk)
+        @router        = router
+        @namespace     = namespace
+        @configuration = configuration
+        @prefix        = Utils::PathPrefix.new(prefix)
         __setobj__(@router)
         instance_eval(&blk)
       end
 
       def root(to:, as: :root, **, &blk)
-        super(to: to, as: route_name(as), prefix: @prefix, namespace: @namespace, &blk)
+        super(to: to, as: route_name(as), prefix: @prefix, namespace: @namespace, configuration: @configuration, &blk)
       end
 
       # @api private
       # @since x.x.x
       def get(path, as: nil, **options, &endpoint)
-        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def post(path, as: nil, **options, &endpoint)
-        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def put(path, as: nil, **options, &endpoint)
-        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def patch(path, as: nil, **options, &endpoint)
-        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def delete(path, as: nil, **options, &endpoint)
-        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def trace(path, as: nil, **options, &endpoint)
-        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def options(path, as: nil, **options, &endpoint)
-        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace), &endpoint)
+        super(@prefix.join(path), options.merge(as: route_name(as), namespace: @namespace, configuration: @configuration), &endpoint)
       end
 
       # @api private
       # @since x.x.x
       def resource(name, options = {})
-        super(name, options.merge(prefix: @prefix.relative_join(options[:prefix]), namespace: @namespace))
+        super(name, options.merge(prefix: @prefix.relative_join(options[:prefix]), namespace: @namespace, configuration: @configuration))
       end
 
       # @api private
       # @since x.x.x
       def resources(name, options = {})
-        super(name, options.merge(prefix: @prefix.relative_join(options[:prefix]), namespace: @namespace))
+        super(name, options.merge(prefix: @prefix.relative_join(options[:prefix]), namespace: @namespace, configuration: @configuration))
       end
 
       # @api private
@@ -96,7 +97,7 @@ module Hanami
       # @api private
       # @since x.x.x
       def prefix(path, &blk)
-        super(@prefix.join(path), namespace: @namespace, &blk)
+        super(@prefix.join(path), namespace: @namespace, configuration: @configuration, &blk)
       end
 
       private

--- a/spec/integration/hanami/router/controller_integration_spec.rb
+++ b/spec/integration/hanami/router/controller_integration_spec.rb
@@ -1,28 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe "Hanami::Controller integration" do
-  before do
-    @routes = Hanami::Router.new do
-      get "/payments", to: CreditCards::Index
-      get "/ccs",      to: "credit_cards#index"
+  let(:app) { Rack::MockRequest.new(router) }
+  let(:router) do
+    Hanami::Router.new(configuration: Action::Configuration.new("credit_cards")) do
+      get "/ccs", to: "credit_cards#index"
       resources :credit_cards, only: [:index]
     end
-
-    @app = Rack::MockRequest.new(@routes)
-  end
-
-  it "recognizes single endpoint (as class)" do
-    response = @app.get("/payments", lint: true)
-    expect(response.body).to eq("Hello from CreditCards::Index")
   end
 
   it "recognizes single endpoint (with naming convention)" do
-    response = @app.get("/ccs", lint: true)
+    response = app.get("/ccs", lint: true)
     expect(response.body).to eq("Hello from CreditCards::Index")
   end
 
   it "recognizes RESTful endpoint" do
-    response = @app.get("/credit_cards", lint: true)
+    response = app.get("/credit_cards", lint: true)
     expect(response.body).to eq("Hello from CreditCards::Index")
   end
 end

--- a/spec/integration/hanami/router/full_stack_application_spec.rb
+++ b/spec/integration/hanami/router/full_stack_application_spec.rb
@@ -1,27 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe "Hanami integration" do
-  before do
-    @router_container = Hanami::Router.new(scheme: "https", host: "hanami.test", port: 443) do
-      mount Dashboard::Index, at: "/dashboard"
-      mount Backend::App, at: "/backend"
-    end
-
-    @routes = Hanami::Router.new(namespace: Travels::Controllers) do
+  let(:app) { Rack::MockRequest.new(router) }
+  let(:router) do
+    Hanami::Router.new(namespace: Travels::Controllers, configuration: Action::Configuration.new("hanami")) do
       get "/dashboard",    to: "journeys#index"
       resources :journeys, only: [:index]
     end
-
-    @app = Rack::MockRequest.new(@routes)
   end
 
   it "recognizes single endpoint" do
-    response = @app.get("/dashboard", lint: true)
+    response = app.get("/dashboard", lint: true)
     expect(response.body).to eq("Hello from Travels::Controllers::Journeys::Index")
   end
 
   it "recognizes RESTful endpoint" do
-    response = @app.get("/journeys", lint: true)
+    response = app.get("/journeys", lint: true)
     expect(response.body).to eq("Hello from Travels::Controllers::Journeys::Index")
   end
 end

--- a/spec/integration/hanami/router/nested_resources_spec.rb
+++ b/spec/integration/hanami/router/nested_resources_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hanami::Router do
 
   context "resource > resource > resource" do
     let(:router) do
-      described_class.new do
+      described_class.new(configuration: configuration) do
         resource :user do
           resource :post do
             resource :comment
@@ -132,7 +132,7 @@ RSpec.describe Hanami::Router do
 
   context "resource > resource > resources" do
     let(:router) do
-      described_class.new do
+      described_class.new(configuration: configuration) do
         resource :user do
           resource :post do
             resources :comments
@@ -188,7 +188,7 @@ RSpec.describe Hanami::Router do
 
   context "resource > resources > resources" do
     let(:router) do
-      described_class.new do
+      described_class.new(configuration: configuration) do
         resource :user do
           resources :posts do
             resources :comments
@@ -288,7 +288,7 @@ RSpec.describe Hanami::Router do
 
   context "resource > resources > resource" do
     let(:router) do
-      described_class.new do
+      described_class.new(configuration: configuration) do
         resource :user do
           resources :posts do
             resource :comment
@@ -338,7 +338,7 @@ RSpec.describe Hanami::Router do
 
   context "resources > resources > resources" do
     let(:router) do
-      described_class.new do
+      described_class.new(configuration: configuration) do
         resources :users do
           resources :posts do
             resources :comments
@@ -482,7 +482,7 @@ RSpec.describe Hanami::Router do
 
   context "resources > resources > resource" do
     let(:router) do
-      described_class.new do
+      described_class.new(configuration: configuration) do
         resources :users do
           resources :posts do
             resource :comment
@@ -532,7 +532,7 @@ RSpec.describe Hanami::Router do
 
   context "resources > resource > resources" do
     let(:router) do
-      described_class.new do
+      described_class.new(configuration: configuration) do
         resources :users do
           resource :post do
             resources :comments do
@@ -657,7 +657,7 @@ RSpec.describe Hanami::Router do
 
   context "resources > resource > resource" do
     let(:router) do
-      described_class.new do
+      described_class.new(configuration: configuration) do
         resources :users do
           resource :post do
             resource :comment

--- a/spec/integration/hanami/router/nested_resources_spec.rb
+++ b/spec/integration/hanami/router/nested_resources_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe Hanami::Router do
   let(:app) { Rack::MockRequest.new(router) }
+  let(:configuration) { Action::Configuration.new("nested_resources") }
 
   context "resource > resource > resource" do
     let(:router) do

--- a/spec/integration/hanami/router/prefix_option_spec.rb
+++ b/spec/integration/hanami/router/prefix_option_spec.rb
@@ -3,24 +3,24 @@
 module Prefix
   module Controllers
     module Home
-      class Index
-        def call(_env)
+      class Index < Action
+        def call(*)
           [200, {}, ["home"]]
         end
       end
     end
 
     module Users
-      class Index
-        def call(_env)
+      class Index < Action
+        def call(*)
           [200, {}, ["users"]]
         end
       end
     end
 
     module Asteroid
-      class Show
-        def call(_env)
+      class Show < Action
+        def call(*)
           [200, {}, ["asteroid"]]
         end
       end
@@ -31,7 +31,7 @@ end
 RSpec.describe Hanami::Router do
   describe "with prefix option" do
     let(:router) do
-      Hanami::Router.new(scheme: "https", host: "hanami.test", port: 443, prefix: "/admin", namespace: Prefix::Controllers) do
+      Hanami::Router.new(scheme: "https", host: "hanami.test", port: 443, prefix: "/admin", namespace: Prefix::Controllers, configuration: Action::Configuration.new("prefix")) do
         get     "/home", to: "home#index", as: :get_home
         post    "/home", to: "home#index", as: :post_home
         put     "/home", to: "home#index", as: :put_home

--- a/spec/integration/hanami/router/prefix_spec.rb
+++ b/spec/integration/hanami/router/prefix_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe Hanami::Router do
   describe "#prefix" do
     let(:app) { Rack::MockRequest.new(router) }
+    let(:configuration) { Action::Configuration.new("prefix") }
 
     it "recognizes get path" do
       router = described_class.new do
@@ -104,7 +105,7 @@ RSpec.describe Hanami::Router do
       end
 
       it "defines #resource correctly" do
-        router = described_class.new do
+        router = described_class.new(configuration: configuration) do
           prefix "users" do
             prefix "management" do
               resource "avatar"
@@ -119,7 +120,7 @@ RSpec.describe Hanami::Router do
       end
 
       it "defines #resources correctly" do
-        router = described_class.new do
+        router = described_class.new(configuration: configuration) do
           prefix "vegetals" do
             prefix "pretty" do
               resources "flowers"
@@ -166,7 +167,7 @@ RSpec.describe Hanami::Router do
 
     context "restful resources" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           prefix "vegetals" do
             resources "flowers"
           end
@@ -210,7 +211,7 @@ RSpec.describe Hanami::Router do
 
       context ":only option" do
         let(:router) do
-          described_class.new do
+          described_class.new(configuration: configuration) do
             prefix "electronics" do
               resources "keyboards", only: %i[index edit]
             end
@@ -238,7 +239,7 @@ RSpec.describe Hanami::Router do
 
       context ":except option" do
         let(:router) do
-          described_class.new do
+          described_class.new(configuration: configuration) do
             prefix "electronics" do
               resources "keyboards", except: %i[new show update destroy]
             end
@@ -267,7 +268,7 @@ RSpec.describe Hanami::Router do
 
       context "additional actions" do
         let(:router) do
-          described_class.new do
+          described_class.new(configuration: configuration) do
             prefix "electronics" do
               resources "keyboards" do
                 collection { get "search" }
@@ -291,7 +292,7 @@ RSpec.describe Hanami::Router do
 
     context "named RESTful resources" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           prefix "vegetals" do
             resources "flowers", as: "tulips"
           end
@@ -336,7 +337,7 @@ RSpec.describe Hanami::Router do
 
     context "restful resource" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           prefix "settings" do
             resource "avatar"
           end
@@ -375,7 +376,7 @@ RSpec.describe Hanami::Router do
 
       context ":only option" do
         let(:router) do
-          described_class.new do
+          described_class.new(configuration: configuration) do
             prefix "settings" do
               resource "profile", only: %i[edit update]
             end
@@ -402,7 +403,7 @@ RSpec.describe Hanami::Router do
 
       context ":except option" do
         let(:router) do
-          described_class.new do
+          described_class.new(configuration: configuration) do
             prefix "settings" do
               resource "profile", except: %i[edit update]
             end
@@ -433,7 +434,7 @@ RSpec.describe Hanami::Router do
 
     context "named RESTful resource" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           prefix "settings" do
             resource "avatar", as: "icon"
           end

--- a/spec/integration/hanami/router/resource_spec.rb
+++ b/spec/integration/hanami/router/resource_spec.rb
@@ -2,10 +2,11 @@
 
 RSpec.describe Hanami::Router do
   let(:app) { Rack::MockRequest.new(router) }
+  let(:configuration) { Action::Configuration.new("resource") }
 
   describe "#resource" do
     let(:router) do
-      described_class.new do
+      described_class.new(configuration: configuration) do
         resource "avatar"
       end
     end
@@ -42,7 +43,7 @@ RSpec.describe Hanami::Router do
 
     context ":only option" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resource "profile", only: %i[edit update]
         end
       end
@@ -67,7 +68,7 @@ RSpec.describe Hanami::Router do
 
     context ":except option" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resource "profile", except: %i[new show create destroy]
         end
       end
@@ -92,7 +93,7 @@ RSpec.describe Hanami::Router do
 
     context "member" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resource "profile", only: [:new] do
             member do
               patch "activate"
@@ -115,7 +116,7 @@ RSpec.describe Hanami::Router do
 
     context "collection" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resource "profile", only: [:new] do
             collection do
               get "keys"
@@ -138,7 +139,7 @@ RSpec.describe Hanami::Router do
 
     context "controller" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resource "profile", controller: "keys", only: [:new]
         end
       end
@@ -151,7 +152,7 @@ RSpec.describe Hanami::Router do
 
     context ":as option" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resource "keyboard", as: "piano" do
             collection do
               get "search"

--- a/spec/integration/hanami/router/resources_spec.rb
+++ b/spec/integration/hanami/router/resources_spec.rb
@@ -2,10 +2,11 @@
 
 RSpec.describe Hanami::Router do
   let(:app) { Rack::MockRequest.new(router) }
+  let(:configuration) { Action::Configuration.new("resources") }
 
   describe "#resources" do
     let(:router) do
-      described_class.new do
+      described_class.new(configuration: configuration) do
         resources "flowers"
       end
     end
@@ -47,7 +48,7 @@ RSpec.describe Hanami::Router do
 
     context ":only option" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resources "keyboards", only: %i[index edit]
         end
       end
@@ -73,7 +74,7 @@ RSpec.describe Hanami::Router do
 
     context ":except option" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resources "keyboards", except: %i[new show update destroy]
         end
       end
@@ -100,7 +101,7 @@ RSpec.describe Hanami::Router do
 
     context "member" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resources "keyboards", only: [:show] do
             member do
               get "screenshot"
@@ -123,7 +124,7 @@ RSpec.describe Hanami::Router do
 
     context "collection" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resources "keyboards", only: [:show] do
             collection do
               get "search"
@@ -146,7 +147,7 @@ RSpec.describe Hanami::Router do
 
     context ":controller option" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resources "keyboards", controller: "keys" do
             collection do
               get "search"
@@ -180,7 +181,7 @@ RSpec.describe Hanami::Router do
 
     context ":as option" do
       let(:router) do
-        described_class.new do
+        described_class.new(configuration: configuration) do
           resources "keyboards", as: "pianos" do
             collection do
               get "search"

--- a/spec/integration/hanami/router/scope_spec.rb
+++ b/spec/integration/hanami/router/scope_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hanami::Router do
     let(:app) { Rack::MockRequest.new(router) }
     let(:router) do
       described_class.new do
-        scope "/admin", namespace: Admin::Controllers do
+        scope "/admin", namespace: Admin::Controllers, configuration: Action::Configuration.new("admin") do
           root to: "home#index"
 
           get  "/signin", to: "sessions#new", as: :signin
@@ -22,7 +22,7 @@ RSpec.describe Hanami::Router do
           mount Backend::App, at: "/backend"
         end
 
-        scope "/", namespace: Web::Controllers do
+        scope "/", namespace: Web::Controllers, configuration: Action::Configuration.new("web") do
           root to: "home#index"
 
           get  "/signin", to: "sessions#new", as: :signin

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -25,63 +25,74 @@ module Middleware
   end
 end
 
+class Action
+  class Configuration
+    attr_reader :name
+
+    def initialize(name)
+      @name = name
+    end
+  end
+
+  attr_reader :configuration
+
+  def initialize(configuration:)
+    raise ArgumentError.new("invalid configuration for #{self.class.name}: #{configuration.inspect}") unless configuration.is_a?(Configuration)
+    @configuration = configuration
+  end
+end
+
 module Web
   module Controllers
     module Home
-      class Index
-        # mocking class call method for middleware
-        def self.call(env)
-          code, headers, body = new.call(env)
-          [code, headers.merge("X-Middleware" => "CALLED"), body]
-        end
-
-        def call(_params)
+      class Index < Action
+        def call(*)
           [200, {}, ["Hello from Web::Controllers::Home::Index"]]
         end
       end
     end # Home
 
     module Dashboard
-      class Index
-        def call(_params)
+      class Index < Action
+        def call(*)
           [200, {}, ["Hello from Web::Controllers::Dashboard::Index"]]
         end
       end
     end # Dashboard
 
     module Sessions
-      class New
-        def call(_params)
+      class New < Action
+        def call(*)
           [200, {}, ["Hello from Web::Controllers::Sessions::New"]]
         end
       end
 
-      class Create
-        def call(_params)
+      class Create < Action
+        def call(*)
           [200, {}, ["Hello from Web::Controllers::Sessions::Create"]]
         end
       end
     end
 
     module Settings
-      class Show
-        def call(_params)
+      class Show < Action
+        def call(*)
           [200, {}, ["Hello from Web::Controllers::Settings::Show"]]
         end
       end
     end
 
     module Users
-      class Show
-        def call(_params)
+      class Show < Action
+        def call(*)
           [200, {}, ["Hello from Web::Controllers::Users::Show"]]
         end
       end
     end
 
     module Topics
-      class Show
-        def call(_params)
+      class Show < Action
+        def call(*)
           [200, {}, ["Hello from Web::Controllers::Topics::Show"]]
         end
       end
@@ -92,46 +103,46 @@ end # Web
 module Admin
   module Controllers
     module Home
-      class Index
-        def call(_params)
+      class Index < Action
+        def call(*)
           [200, {}, ["Hello from Admin::Controllers::Home::Index"]]
         end
       end
     end # Home
 
     module Sessions
-      class New
-        def call(_params)
+      class New < Action
+        def call(*)
           [200, {}, ["Hello from Admin::Controllers::Sessions::New"]]
         end
       end
 
-      class Create
-        def call(_params)
+      class Create < Action
+        def call(*)
           [200, {}, ["Hello from Admin::Controllers::Sessions::Create"]]
         end
       end
     end
 
     module Settings
-      class Show
-        def call(_params)
+      class Show < Action
+        def call(*)
           [200, {}, ["Hello from Admin::Controllers::Settings::Show"]]
         end
       end
     end
 
     module Users
-      class Show
-        def call(_params)
+      class Show < Action
+        def call(*)
           [200, {}, ["Hello from Admin::Controllers::Users::Show"]]
         end
       end
     end
 
     module Topics
-      class Show
-        def call(_params)
+      class Show < Action
+        def call(*)
           [200, {}, ["Hello from Admin::Controllers::Topics::Show"]]
         end
       end
@@ -242,143 +253,143 @@ module Controllers
 end
 
 module Avatar
-  class New
-    def call(_env)
+  class New < Action
+    def call(*)
       [200, {}, ["Avatar::New"]]
     end
   end
 
-  class Create
-    def call(_env)
+  class Create < Action
+    def call(*)
       [200, {}, ["Avatar::Create"]]
     end
   end
 
-  class Show
-    def call(_env)
+  class Show < Action
+    def call(*)
       [200, {}, ["Avatar::Show"]]
     end
   end
 
-  class Edit
-    def call(_env)
+  class Edit < Action
+    def call(*)
       [200, {}, ["Avatar::Edit"]]
     end
   end
 
-  class Update
-    def call(_env)
+  class Update < Action
+    def call(*)
       [200, {}, ["Avatar::Update"]]
     end
   end
 
-  class Destroy
-    def call(_env)
+  class Destroy < Action
+    def call(*)
       [200, {}, ["Avatar::Destroy"]]
     end
   end
 end # Avatar
 
 module Profile
-  class Show
-    def call(_env)
+  class Show < Action
+    def call(*)
       [200, {}, ["Profile::Show"]]
     end
   end
 
-  class New
-    def call(_env)
+  class New < Action
+    def call(*)
       [200, {}, ["Profile::New"]]
     end
   end
 
-  class Create
-    def call(_env)
+  class Create < Action
+    def call(*)
       [200, {}, ["Profile::Create"]]
     end
   end
 
-  class Edit
-    def call(_env)
+  class Edit < Action
+    def call(*)
       [200, {}, ["Profile::Edit"]]
     end
   end
 
-  class Update
-    def call(_env)
+  class Update < Action
+    def call(*)
       [200, {}, ["Profile::Update"]]
     end
   end
 
-  class Destroy
-    def call(_env)
+  class Destroy < Action
+    def call(*)
       [200, {}, ["Profile::Destroy"]]
     end
   end
 
-  class Activate
-    def call(_env)
+  class Activate < Action
+    def call(*)
       [200, {}, ["Profile::Activate"]]
     end
   end
 
-  class Deactivate
-    def call(_env)
+  class Deactivate < Action
+    def call(*)
       [200, {}, ["Profile::Deactivate"]]
     end
   end
 
-  class Keys
-    def call(_env)
+  class Keys < Action
+    def call(*)
       [200, {}, ["Profile::Keys"]]
     end
   end
 
-  class Activities
-    def call(_env)
+  class Activities < Action
+    def call(*)
       [200, {}, ["Profile::Activities"]]
     end
   end
 end # Profile
 
 module Flowers
-  class Index
-    def call(_env)
+  class Index < Action
+    def call(*)
       [200, {}, ["Flowers::Index"]]
     end
   end
 
-  class New
-    def call(_env)
+  class New < Action
+    def call(*)
       [200, {}, ["Flowers::New"]]
     end
   end
 
-  class Create
-    def call(_env)
+  class Create < Action
+    def call(*)
       [200, {}, ["Flowers::Create"]]
     end
   end
 
-  class Show
+  class Show < Action
     def call(env)
       [200, {}, ["Flowers::Show " + env["router.params"][:id]]]
     end
   end
 
-  class Edit
+  class Edit < Action
     def call(env)
       [200, {}, ["Flowers::Edit " + env["router.params"][:id]]]
     end
   end
 
-  class Update
+  class Update < Action
     def call(env)
       [200, {}, ["Flowers::Update " + env["router.params"][:id]]]
     end
   end
 
-  class Destroy
+  class Destroy < Action
     def call(env)
       [200, {}, ["Flowers::Destroy " + env["router.params"][:id]]]
     end
@@ -386,105 +397,105 @@ module Flowers
 end # Flowers
 
 module Keyboards
-  class Index
-    def call(_env)
+  class Index < Action
+    def call(*)
       [200, {}, ["Keyboards::Index"]]
     end
   end
 
-  class Create
-    def call(_env)
+  class Create < Action
+    def call(*)
       [200, {}, ["Keyboards::Create"]]
     end
   end
 
-  class Edit
+  class Edit < Action
     def call(env)
       [200, {}, ["Keyboards::Edit " + env["router.params"][:id]]]
     end
   end
 
-  class Show
+  class Show < Action
     def call(env)
       [200, {}, ["Keyboards::Show " + env["router.params"][:id]]]
     end
   end
 
-  class Search
-    def call(_env)
+  class Search < Action
+    def call(*)
       [200, {}, ["Keyboards::Search"]]
     end
   end
 
-  class Screenshot
+  class Screenshot < Action
     def call(env)
       [200, {}, ["Keyboards::Screenshot " + env["router.params"][:id]]]
     end
   end
 
-  class Print
+  class Print < Action
     def call(env)
       [200, {}, ["Keyboards::Print " + env["router.params"][:id]]]
     end
   end
 
-  class Characters
-    def call(_env)
+  class Characters < Action
+    def call(*)
       [200, {}, ["Keyboards::Characters"]]
     end
   end
 end # Keyboards
 
 module Keys
-  class Index
-    def call(_env)
+  class Index < Action
+    def call(*)
       [200, {}, ["Keys::Index"]]
     end
   end
 
-  class New
-    def call(_env)
+  class New < Action
+    def call(*)
       [200, {}, ["Keys::New"]]
     end
   end
 
-  class Create
-    def call(_env)
+  class Create < Action
+    def call(*)
       [200, {}, ["Keys::Create"]]
     end
   end
 
-  class Edit
+  class Edit < Action
     def call(env)
       [200, {}, ["Keys::Edit " + env["router.params"][:id]]]
     end
   end
 
-  class Update
+  class Update < Action
     def call(env)
       [200, {}, ["Keys::Update " + env["router.params"][:id]]]
     end
   end
 
-  class Show
+  class Show < Action
     def call(env)
       [200, {}, ["Keys::Show " + env["router.params"][:id]]]
     end
   end
 
-  class Destroy
+  class Destroy < Action
     def call(env)
       [200, {}, ["Keys::Destroy " + env["router.params"][:id]]]
     end
   end
 
-  class Search
-    def call(_env)
+  class Search < Action
+    def call(*)
       [200, {}, ["Keys::Search"]]
     end
   end
 
-  class Screenshot
+  class Screenshot < Action
     def call(env)
       [200, {}, ["Keys::Screenshot " + env["router.params"][:id]]]
     end
@@ -519,8 +530,8 @@ class RackMiddlewareInstanceMethod
 end
 
 module CreditCards
-  class Index
-    def call(_env)
+  class Index < Action
+    def call(*)
       [200, {}, ["Hello from CreditCards::Index"]]
     end
   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -540,8 +540,8 @@ end
 module Travels
   module Controllers
     module Journeys
-      class Index
-        def call(_env)
+      class Index < Action
+        def call(*)
           [200, {}, ["Hello from Travels::Controllers::Journeys::Index"]]
         end
       end
@@ -613,110 +613,111 @@ end
 
 # resource > resource > resource
 module User
-  class New
-    def call(_env)
+  class New < Action
+    def call(*)
       [200, {}, ["User::New"]]
     end
   end
 
-  class Create
-    def call(_env)
+  class Create < Action
+    def call(*)
       [200, {}, ["User::Create"]]
     end
   end
 
-  class Show
-    def call(_env)
+  class Show < Action
+    def call(*)
       [200, {}, ["User::Show"]]
     end
   end
 
-  class Edit
-    def call(_env)
+  class Edit < Action
+    def call(*)
       [200, {}, ["User::Edit"]]
     end
   end
 
-  class Update
-    def call(_env)
+  class Update < Action
+    def call(*)
       [200, {}, ["User::Update"]]
     end
   end
 
-  class Destroy
-    def call(_env)
+  class Destroy < Action
+    def call(*)
       [200, {}, ["User::Destroy"]]
     end
   end
+
   module Post
-    class New
-      def call(_env)
+    class New < Action
+      def call(*)
         [200, {}, ["User::Post::New"]]
       end
     end
 
-    class Create
-      def call(_env)
+    class Create < Action
+      def call(*)
         [200, {}, ["User::Post::Create"]]
       end
     end
 
-    class Show
-      def call(_env)
+    class Show < Action
+      def call(*)
         [200, {}, ["User::Post::Show"]]
       end
     end
 
-    class Edit
-      def call(_env)
+    class Edit < Action
+      def call(*)
         [200, {}, ["User::Post::Edit"]]
       end
     end
 
-    class Update
-      def call(_env)
+    class Update < Action
+      def call(*)
         [200, {}, ["User::Post::Update"]]
       end
     end
 
-    class Destroy
-      def call(_env)
+    class Destroy < Action
+      def call(*)
         [200, {}, ["User::Post::Destroy"]]
       end
     end
     module Comment
-      class New
-        def call(_env)
+      class New < Action
+        def call(*)
           [200, {}, ["User::Post::Comment::New"]]
         end
       end
 
-      class Create
-        def call(_env)
+      class Create < Action
+        def call(*)
           [200, {}, ["User::Post::Comment::Create"]]
         end
       end
 
-      class Show
-        def call(_env)
+      class Show < Action
+        def call(*)
           [200, {}, ["User::Post::Comment::Show"]]
         end
       end
 
-      class Edit
-        def call(_env)
+      class Edit < Action
+        def call(*)
           [200, {}, ["User::Post::Comment::Edit"]]
         end
       end
 
-      class Update
-        def call(_env)
+      class Update < Action
+        def call(*)
           [200, {}, ["User::Post::Comment::Update"]]
         end
       end
 
-      class Destroy
-        def call(_env)
+      class Destroy < Action
+        def call(*)
           [200, {}, ["User::Post::Comment::Destroy"]]
         end
       end
@@ -728,44 +729,44 @@ end
 module User
   module Post
     module Comments
-      class Index
-        def call(_env)
+      class Index < Action
+        def call(*)
           [200, {}, ["User::Post::Comments::Index"]]
         end
       end
 
-      class New
-        def call(_env)
+      class New < Action
+        def call(*)
           [200, {}, ["User::Post::Comments::New"]]
         end
       end
 
-      class Create
-        def call(_env)
+      class Create < Action
+        def call(*)
           [200, {}, ["User::Post::Comments::Create"]]
         end
       end
 
-      class Show
-        def call(_env)
+      class Show < Action
+        def call(*)
           [200, {}, ["User::Post::Comments::Show"]]
         end
       end
 
-      class Edit
-        def call(_env)
+      class Edit < Action
+        def call(*)
           [200, {}, ["User::Post::Comments::Edit"]]
         end
       end
 
-      class Update
-        def call(_env)
+      class Update < Action
+        def call(*)
           [200, {}, ["User::Post::Comments::Update"]]
         end
       end
 
-      class Destroy
-        def call(_env)
+      class Destroy < Action
+        def call(*)
           [200, {}, ["User::Post::Comments::Destroy"]]
         end
       end
@@ -776,87 +777,87 @@ end
 # resource > resources > resources
 module User
   module Posts
-    class Index
-      def call(_env)
+    class Index < Action
+      def call(*)
         [200, {}, ["User::Posts::Index"]]
       end
     end
 
-    class New
-      def call(_env)
+    class New < Action
+      def call(*)
         [200, {}, ["User::Posts::New"]]
       end
     end
 
-    class Create
-      def call(_env)
+    class Create < Action
+      def call(*)
         [200, {}, ["User::Posts::Create"]]
       end
     end
 
-    class Show
-      def call(_env)
+    class Show < Action
+      def call(*)
         [200, {}, ["User::Posts::Show"]]
       end
     end
 
-    class Edit
-      def call(_env)
+    class Edit < Action
+      def call(*)
         [200, {}, ["User::Posts::Edit"]]
       end
     end
 
-    class Update
-      def call(_env)
+    class Update < Action
+      def call(*)
         [200, {}, ["User::Posts::Update"]]
       end
     end
 
-    class Destroy
-      def call(_env)
+    class Destroy < Action
+      def call(*)
         [200, {}, ["User::Posts::Destroy"]]
       end
     end
 
     module Comments
-      class Index
-        def call(_env)
+      class Index < Action
+        def call(*)
           [200, {}, ["User::Posts::Comments::Index"]]
         end
       end
 
-      class New
-        def call(_env)
+      class New < Action
+        def call(*)
           [200, {}, ["User::Posts::Comments::New"]]
         end
       end
 
-      class Create
-        def call(_env)
+      class Create < Action
+        def call(*)
           [200, {}, ["User::Posts::Comments::Create"]]
         end
       end
 
-      class Show
-        def call(_env)
+      class Show < Action
+        def call(*)
           [200, {}, ["User::Posts::Comments::Show"]]
         end
       end
 
-      class Edit
-        def call(_env)
+      class Edit < Action
+        def call(*)
           [200, {}, ["User::Posts::Comments::Edit"]]
         end
       end
 
-      class Update
-        def call(_env)
+      class Update < Action
+        def call(*)
           [200, {}, ["User::Posts::Comments::Update"]]
         end
       end
 
-      class Destroy
-        def call(_env)
+      class Destroy < Action
+        def call(*)
           [200, {}, ["User::Posts::Comments::Destroy"]]
         end
       end
@@ -868,38 +869,38 @@ end
 module User
   module Posts
     module Comment
-      class New
-        def call(_env)
+      class New < Action
+        def call(*)
           [200, {}, ["User::Posts::Comment::New"]]
         end
       end
 
-      class Create
-        def call(_env)
+      class Create < Action
+        def call(*)
           [200, {}, ["User::Posts::Comment::Create"]]
         end
       end
 
-      class Show
-        def call(_env)
+      class Show < Action
+        def call(*)
           [200, {}, ["User::Posts::Comment::Show"]]
         end
       end
 
-      class Edit
-        def call(_env)
+      class Edit < Action
+        def call(*)
           [200, {}, ["User::Posts::Comment::Edit"]]
         end
       end
 
-      class Update
-        def call(_env)
+      class Update < Action
+        def call(*)
           [200, {}, ["User::Posts::Comment::Update"]]
         end
       end
 
-      class Destroy
-        def call(_env)
+      class Destroy < Action
+        def call(*)
           [200, {}, ["User::Posts::Comment::Destroy"]]
         end
       end
@@ -909,130 +910,130 @@ end
 
 # resources > resources > resources
 module Users
-  class Index
-    def call(_env)
+  class Index < Action
+    def call(*)
       [200, {}, ["Users::Index"]]
     end
   end
 
-  class New
-    def call(_env)
+  class New < Action
+    def call(*)
       [200, {}, ["Users::New"]]
     end
   end
 
-  class Create
-    def call(_env)
+  class Create < Action
+    def call(*)
       [200, {}, ["Users::Create"]]
     end
   end
 
-  class Show
-    def call(_env)
+  class Show < Action
+    def call(*)
       [200, {}, ["Users::Show"]]
     end
   end
 
-  class Edit
-    def call(_env)
+  class Edit < Action
+    def call(*)
       [200, {}, ["Users::Edit"]]
     end
   end
 
-  class Update
-    def call(_env)
+  class Update < Action
+    def call(*)
       [200, {}, ["Users::Update"]]
     end
   end
 
-  class Destroy
-    def call(_env)
+  class Destroy < Action
+    def call(*)
       [200, {}, ["Users::Destroy"]]
     end
   end
 
   module Posts
-    class Index
-      def call(_env)
+    class Index < Action
+      def call(*)
         [200, {}, ["Users::Posts::Index"]]
       end
     end
 
-    class New
-      def call(_env)
+    class New < Action
+      def call(*)
         [200, {}, ["Users::Posts::New"]]
       end
     end
 
-    class Create
-      def call(_env)
+    class Create < Action
+      def call(*)
         [200, {}, ["Users::Posts::Create"]]
       end
     end
 
-    class Show
-      def call(_env)
+    class Show < Action
+      def call(*)
         [200, {}, ["Users::Posts::Show"]]
       end
     end
 
-    class Edit
-      def call(_env)
+    class Edit < Action
+      def call(*)
         [200, {}, ["Users::Posts::Edit"]]
       end
     end
 
-    class Update
-      def call(_env)
+    class Update < Action
+      def call(*)
         [200, {}, ["Users::Posts::Update"]]
       end
     end
 
-    class Destroy
-      def call(_env)
+    class Destroy < Action
+      def call(*)
         [200, {}, ["Users::Posts::Destroy"]]
       end
     end
 
     module Comments
-      class Index
-        def call(_env)
+      class Index < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comments::Index"]]
         end
       end
 
-      class New
-        def call(_env)
+      class New < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comments::New"]]
         end
       end
 
-      class Create
-        def call(_env)
+      class Create < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comments::Create"]]
         end
       end
 
-      class Show
-        def call(_env)
+      class Show < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comments::Show"]]
         end
       end
 
-      class Edit
-        def call(_env)
+      class Edit < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comments::Edit"]]
         end
       end
 
-      class Update
-        def call(_env)
+      class Update < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comments::Update"]]
         end
       end
 
-      class Destroy
-        def call(_env)
+      class Destroy < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comments::Destroy"]]
         end
       end
@@ -1044,38 +1045,38 @@ end # User
 module Users
   module Posts
     module Comment
-      class New
-        def call(_env)
+      class New < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comment::New"]]
         end
       end
 
-      class Create
-        def call(_env)
+      class Create < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comment::Create"]]
         end
       end
 
-      class Show
-        def call(_env)
+      class Show < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comment::Show"]]
         end
       end
 
-      class Edit
-        def call(_env)
+      class Edit < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comment::Edit"]]
         end
       end
 
-      class Update
-        def call(_env)
+      class Update < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comment::Update"]]
         end
       end
 
-      class Destroy
-        def call(_env)
+      class Destroy < Action
+        def call(*)
           [200, {}, ["Users::Posts::Comment::Destroy"]]
         end
       end
@@ -1086,104 +1087,105 @@ end
 # resources > resource > resources
 module Users
   module Post
-    class New
-      def call(_env)
+    class New < Action
+      def call(*)
         [200, {}, ["Users::Post::New"]]
       end
     end
 
-    class Create
-      def call(_env)
+    class Create < Action
+      def call(*)
         [200, {}, ["Users::Post::Create"]]
       end
     end
 
-    class Show
-      def call(_env)
+    class Show < Action
+      def call(*)
         [200, {}, ["Users::Post::Show"]]
       end
     end
 
-    class Edit
-      def call(_env)
+    class Edit < Action
+      def call(*)
         [200, {}, ["Users::Post::Edit"]]
       end
     end
 
-    class Update
-      def call(_env)
+    class Update < Action
+      def call(*)
         [200, {}, ["Users::Post::Update"]]
       end
     end
 
-    class Destroy
-      def call(_env)
+    class Destroy < Action
+      def call(*)
         [200, {}, ["Users::Post::Destroy"]]
       end
     end
 
-    class Search
-      def call(_env)
+    class Search < Action
+      def call(*)
         [200, {}, ["Users::Post::Search"]]
       end
     end
 
-    class Screenshot
-      def call(_env)
+    class Screenshot < Action
+      def call(*)
         [200, {}, ["Users::Post::Screenshot"]]
       end
     end
+
     module Comments
-      class Index
-        def call(_env)
+      class Index < Action
+        def call(*)
           [200, {}, ["Users::Post::Comments::Index"]]
         end
       end
 
-      class New
-        def call(_env)
+      class New < Action
+        def call(*)
           [200, {}, ["Users::Post::Comments::New"]]
         end
       end
 
-      class Create
-        def call(_env)
+      class Create < Action
+        def call(*)
           [200, {}, ["Users::Post::Comments::Create"]]
         end
       end
 
-      class Show
-        def call(_env)
+      class Show < Action
+        def call(*)
           [200, {}, ["Users::Post::Comments::Show"]]
         end
       end
 
-      class Edit
-        def call(_env)
+      class Edit < Action
+        def call(*)
           [200, {}, ["Users::Post::Comments::Edit"]]
         end
       end
 
-      class Update
-        def call(_env)
+      class Update < Action
+        def call(*)
           [200, {}, ["Users::Post::Comments::Update"]]
         end
       end
 
-      class Destroy
-        def call(_env)
+      class Destroy < Action
+        def call(*)
           [200, {}, ["Users::Post::Comments::Destroy"]]
         end
       end
 
-      class Search
-        def call(_env)
+      class Search < Action
+        def call(*)
           [200, {}, ["Users::Post::Comments::Search"]]
         end
       end
 
-      class Screenshot
-        def call(_env)
+      class Screenshot < Action
+        def call(*)
           [200, {}, ["Users::Post::Comments::Screenshot"]]
         end
       end
@@ -1195,38 +1197,38 @@ end
 module Users
   module Post
     module Comment
-      class New
-        def call(_env)
+      class New < Action
+        def call(*)
           [200, {}, ["Users::Post::Comment::New"]]
         end
       end
 
-      class Create
-        def call(_env)
+      class Create < Action
+        def call(*)
           [200, {}, ["Users::Post::Comment::Create"]]
         end
       end
 
-      class Show
-        def call(_env)
+      class Show < Action
+        def call(*)
           [200, {}, ["Users::Post::Comment::Show"]]
         end
       end
 
-      class Edit
-        def call(_env)
+      class Edit < Action
+        def call(*)
           [200, {}, ["Users::Post::Comment::Edit"]]
         end
       end
 
-      class Update
-        def call(_env)
+      class Update < Action
+        def call(*)
           [200, {}, ["Users::Post::Comment::Update"]]
         end
       end
 
-      class Destroy
-        def call(_env)
+      class Destroy < Action
+        def call(*)
           [200, {}, ["Users::Post::Comment::Destroy"]]
         end
       end

--- a/spec/unit/hanami/router/new_spec.rb
+++ b/spec/unit/hanami/router/new_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hanami::Router do
     let(:router) do
       e = endpoint
 
-      described_class.new do
+      described_class.new(configuration: Action::Configuration.new("new")) do
         root                to: e
         get "/route",       to: e
         get "/named_route", to: e, as: :named_route

--- a/spec/unit/hanami/router/recognize_spec.rb
+++ b/spec/unit/hanami/router/recognize_spec.rb
@@ -3,9 +3,11 @@
 RSpec.describe Hanami::Router do
   describe "#recognize" do
     let(:router) do
-      Hanami::Router.new(namespace: Web::Controllers) do
-        get "/",              to: "home#index",                       as: :home
-        get "/dashboard",     to: Web::Controllers::Dashboard::Index, as: :dashboard
+      configuration = Action::Configuration.new("recognize")
+
+      Hanami::Router.new(namespace: Web::Controllers, configuration: configuration) do
+        get "/",              to: "home#index",                                                         as: :home
+        get "/dashboard",     to: Web::Controllers::Dashboard::Index.new(configuration: configuration), as: :dashboard
         get "/rack_class",    to: RackMiddleware,                     as: :rack_class
         get "/rack_app",      to: RackMiddlewareInstanceMethod,       as: :rack_app
         get "/proc",          to: ->(_env) { [200, {}, ["OK"]] },     as: :proc
@@ -26,7 +28,7 @@ RSpec.describe Hanami::Router do
 
         expect(route.routable?).to be(true)
         expect(route.redirect?).to be(false)
-        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:11 (lambda)")
+        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:13 (lambda)")
         expect(route.redirection_path).to be(nil)
         expect(route.verb).to eq("GET")
         expect(route.path).to eq("/proc")
@@ -39,7 +41,7 @@ RSpec.describe Hanami::Router do
 
         expect(route.routable?).to be(true)
         expect(route.redirect?).to be(false)
-        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:12 (lambda)")
+        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:14 (lambda)")
         expect(route.redirection_path).to be(nil)
         expect(route.verb).to eq("GET")
         expect(route.path).to eq("/resources/1")
@@ -63,7 +65,7 @@ RSpec.describe Hanami::Router do
         expect(route.params).to eq({})
       end
 
-      it "recognizes action from class" do
+      it "recognizes action from instance" do
         env   = Rack::MockRequest.env_for("/dashboard", method: :get)
         route = router.recognize(env)
 
@@ -176,7 +178,7 @@ RSpec.describe Hanami::Router do
 
         expect(route.routable?).to be(true)
         expect(route.redirect?).to be(false)
-        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:11 (lambda)")
+        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:13 (lambda)")
         expect(route.redirection_path).to be(nil)
         expect(route.verb).to eq("GET")
         expect(route.path).to eq("/proc")
@@ -188,7 +190,7 @@ RSpec.describe Hanami::Router do
 
         expect(route.routable?).to be(true)
         expect(route.redirect?).to be(false)
-        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:12 (lambda)")
+        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:14 (lambda)")
         expect(route.redirection_path).to be(nil)
         expect(route.verb).to eq("GET")
         expect(route.path).to eq("/resources/1")
@@ -211,7 +213,7 @@ RSpec.describe Hanami::Router do
         expect(route.params).to eq({})
       end
 
-      it "recognizes action from class" do
+      it "recognizes action from instance" do
         route = router.recognize("/dashboard")
 
         _, _, body = *route.call({})
@@ -332,7 +334,7 @@ RSpec.describe Hanami::Router do
 
         expect(route.routable?).to be(true)
         expect(route.redirect?).to be(false)
-        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:11 (lambda)")
+        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:13 (lambda)")
         expect(route.redirection_path).to be(nil)
         expect(route.verb).to eq("GET")
         expect(route.path).to eq("/proc")
@@ -344,7 +346,7 @@ RSpec.describe Hanami::Router do
 
         expect(route.routable?).to be(true)
         expect(route.redirect?).to be(false)
-        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:12 (lambda)")
+        expect(route.action).to include("spec/unit/hanami/router/recognize_spec.rb:14 (lambda)")
         expect(route.redirection_path).to be(nil)
         expect(route.verb).to eq("GET")
         expect(route.path).to eq("/resources/1")
@@ -367,7 +369,7 @@ RSpec.describe Hanami::Router do
         expect(route.params).to eq({})
       end
 
-      it "recognizes action from class" do
+      it "recognizes action from instance" do
         route = router.recognize(:dashboard)
 
         _, _, body = *route.call({})

--- a/spec/unit/hanami/routing/endpoint_spec.rb
+++ b/spec/unit/hanami/routing/endpoint_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hanami::Routing::Endpoint do
       end
 
       it "finds Hanami action" do
-        expect(described_class.find("home#index", Web::Controllers)).to be_kind_of(Web::Controllers::Home::Index)
+        expect(described_class.find("home#index", Web::Controllers, Action::Configuration.new("web"))).to be_kind_of(Web::Controllers::Home::Index)
       end
 
       it "returns a lazy endpoint when the class cannot be found" do


### PR DESCRIPTION
This is a followup of #157. I tried to split the amount of changes between the two PRs, also because this one introduces a breaking change.

## Background

In order to make Hanami faster, since 2.0, the router will hold immutable action instances to serve all the incoming requests. With 1.x, it used to hold the action class and to create a new instance for each request.

Code sketch:

```ruby
# 1.x
@action.class # => Class
@action.name # => Web::Controllers::Home::Index
@action.new.call(env) # new instance for each request

# 2.x
@action.class # => Web::Controllers::Home::Index
@action.call(env) # always the same instance for all the requests
```

## Problem

Given that `hanami-controller` 2.0 needs an instance of `Hanami::Controller::Configuration` to be instantiated, this PR introduces a new keyword `:controller` for `Hanami::Router#initialize`.

## Proposed solution

On 1.x series it was:

```ruby
module Web
  module Controllers
    module Home
      class Index
        include Web::Action

        def call(params)
        end
      end
    end
  end
end

router = Hanami::Router.new(namespace: Web::Controllers) do
  root to: "home#index"
end
```

On 2.x, I suggest:

```ruby
module Web
  module Controllers
    module Home
      class Index < Hanami::Action
        def call(*)
        end
      end
    end
  end
end

configuration = Hanami::Controller::Configuration.new
router = Hanami::Router.new(configuration: configuration, namespace: Web::Controllers) do
  root to: "home#index"
end
```

Regarding the changes introduced by #157, this PR adds another keyword argument for `Hanami::Router#scope`: `:configuration`.

```ruby
admin = Hanami::Controller::Configuration.new
web = Hanami::Controller::Configuration.new

router = Hanami::Router.new do
  scope "/admin", namespace: Admin::Controllers, configuration: admin do
    # ...
  end

  scope "/", namespace: Web::Controllers, configuration: web do
    # ...
  end
end
```

---

**Please note** that the usage described in this PR it only concerns **standalone usage** of `hanami-router` and `hanami-controller`. Hanami users (`hanami`), won't see the difference.