### PR TITLE
remove body cleanup for HEAD requests

### DIFF
--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -1035,10 +1035,7 @@ module Hanami
       if (response = @force_ssl.call(env))
         response
       else
-        enforce_head(
-          env,
-          (@routes.find { |r| r.match?(env) } || fallback(env)).call(@parsers.call(env))
-        )
+        (@routes.find { |r| r.match?(env) } || fallback(env)).call(@parsers.call(env))
       end
     end
 
@@ -1353,18 +1350,6 @@ module Hanami
 
       @routes.push(route)
       @named[as] = route unless as.nil?
-    end
-
-    def enforce_head(env, response)
-      if env[REQUEST_METHOD] == HEAD
-        if response.respond_to?(:body)
-          response.body = []
-        else
-          response[BODY] = []
-        end
-      end
-
-      response
     end
 
     def verb_for(value)

--- a/spec/integration/hanami/router/mount_spec.rb
+++ b/spec/integration/hanami/router/mount_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hanami::Router do
     end
   end
 
-  let(:app) { Rack::MockRequest.new(router) }
+  let(:app) { Rack::MockRequest.new(Rack::Head.new(router)) }
 
   RSpec::Support::HTTP.verbs.each do |verb|
     it "accepts #{verb} for a class endpoint" do

--- a/spec/integration/hanami/router/prefix_spec.rb
+++ b/spec/integration/hanami/router/prefix_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Hanami::Router do
   describe "#prefix" do
-    let(:app) { Rack::MockRequest.new(router) }
+    let(:app) { Rack::MockRequest.new(Rack::Head.new(router)) }
     let(:configuration) { Action::Configuration.new("prefix") }
 
     it "recognizes get path" do

--- a/spec/integration/hanami/router/routing_spec.rb
+++ b/spec/integration/hanami/router/routing_spec.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
+def build_response(response, requested)
+  return response unless requested == "head"
+  response.body = []
+  response
+end
+
 RSpec.describe Hanami::Router do
-  let(:app) { Rack::MockRequest.new(router) }
+  let(:app) { Rack::MockRequest.new(Rack::Head.new(router)) }
 
   RSpec::Support::HTTP.mountable_verbs.each do |verb|
     context "##{verb}" do
@@ -25,7 +31,7 @@ RSpec.describe Hanami::Router do
 
         context "path recognition" do
           context "fixed string" do
-            let(:response) { Rack::MockResponse.new(200, { "Content-Length" => "6" }, "Fixed!") }
+            let(:response) { build_response(Rack::MockResponse.new(200, { "Content-Length" => "6" }, "Fixed!"), requested) }
 
             it "recognizes" do
               actual = app.request(requested.upcase, "/hanami", lint: true)
@@ -37,7 +43,7 @@ RSpec.describe Hanami::Router do
           end
 
           context "moving parts string" do
-            let(:response) { Rack::MockResponse.new(200, { "Content-Length" => "7" }, "Moving!") }
+            let(:response) { build_response(Rack::MockResponse.new(200, { "Content-Length" => "7" }, "Moving!"), requested) }
 
             it "recognizes" do
               actual = app.request(requested.upcase, "/hanami/23", lint: true)
@@ -49,7 +55,7 @@ RSpec.describe Hanami::Router do
           end
 
           context "globbing string" do
-            let(:response) { Rack::MockResponse.new(200, { "Content-Length" => "9" }, "Globbing!") }
+            let(:response) { build_response(Rack::MockResponse.new(200, { "Content-Length" => "9" }, "Globbing!"), requested) }
 
             it "recognizes" do
               actual = app.request(requested.upcase, "/hanami/all", lint: true)
@@ -61,7 +67,7 @@ RSpec.describe Hanami::Router do
           end
 
           context "format string" do
-            let(:response) { Rack::MockResponse.new(200, { "Content-Length" => "7" }, "Format!") }
+            let(:response) { build_response(Rack::MockResponse.new(200, { "Content-Length" => "7" }, "Format!"), requested) }
 
             it "recognizes" do
               actual = app.request(requested.upcase, "/hanami/all.json", lint: true)
@@ -73,7 +79,7 @@ RSpec.describe Hanami::Router do
           end
 
           context "block" do
-            let(:response) { Rack::MockResponse.new(200, { "Content-Length" => "6" }, "Block!") }
+            let(:response) { build_response(Rack::MockResponse.new(200, { "Content-Length" => "6" }, "Block!"), requested) }
 
             it "recognizes" do
               actual = app.request(requested.upcase, "/block", lint: true)
@@ -119,7 +125,7 @@ RSpec.describe Hanami::Router do
         end
 
         describe "constraints" do
-          let(:response) { Rack::MockResponse.new(200, { "Content-Length" => "24" }, "Moving with constraints!") }
+          let(:response) { build_response(Rack::MockResponse.new(200, { "Content-Length" => "24" }, "Moving with constraints!"), requested) }
 
           it "recognize when called with matching constraints" do
             expect(app.request(requested.upcase, "/books/23", lint: true)).to be(response)

--- a/spec/integration/hanami/router/scope_spec.rb
+++ b/spec/integration/hanami/router/scope_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Hanami::Router do
   describe "#scope" do
-    let(:app) { Rack::MockRequest.new(router) }
+    let(:app) { Rack::MockRequest.new(Rack::Head.new(router)) }
     let(:router) do
       described_class.new do
         scope "/admin", namespace: Admin::Controllers, configuration: Action::Configuration.new("admin") do


### PR DESCRIPTION
Fixes #164 

@jodosha when removing the code that was cleaning the body for `HEAD` requests, many tests fail because we are using `lint` for `Rack::MockResponse`. 

To fix that I use `Rack::Head` middleware to solve it, also had to add a special case for the `routing_spec` by modifying the body depending on the type of request.

WDYT?