### PR TITLE
Path generation bug for regex constraint with leading carrot

### DIFF
--- a/spec/unit/hanami/router/path_spec.rb
+++ b/spec/unit/hanami/router/path_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Hanami::Router do
     @router.get('/files/*',              to: endpoint, as: :glob)
     @router.resources(:leaves,                         as: :resources)
     @router.resource(:stem,                            as: :singular_resource)
+    @router.get('/books/:slug',
+                slug: /^[a-z]+$/,
+                to: endpoint,
+                as: :slug_constraints)
   end
 
   after do
@@ -36,6 +40,14 @@ RSpec.describe Hanami::Router do
 
     it "raises error when constraints aren't satisfied" do
       expect { @router.path(:constraints, id: 'x') }.to raise_error(Hanami::Routing::InvalidRouteException, 'No route (path) could be generated for :constraints - please check given arguments')
+    end
+
+    it 'recognizes string with variables and constraints' do
+      expect(@router.path(:slug_constraints, slug: "hello")).to eq('/books/hello')
+    end
+
+    it "raises error when constraints aren't satisfied" do
+      expect { @router.path(:slug_constraints, slug: '123') }.to raise_error(Hanami::Routing::InvalidRouteException, 'No route (path) could be generated for :slug_constraints - please check given arguments')
     end
 
     it 'recognizes optional variables' do


### PR DESCRIPTION
I just found this bug (Hanami 1.2.0), where specifying a regex with a leading `^` (beginning of string meta-character) will cause the path helpers to fail to find the correct path. 

I have a (currently failing) spec below demonstrating this problem. If you remove the `^`, it works fine. 

(The example also has a trailing `$`, but that's not causing problems.)

In terms of writing this spec, it might make sense to simplify the spec by just replacing the `constraints` example with this one, which I've called `slug_constraints`.