### PR TITLE
Replace Utils::String instance methods with class methods

### DIFF
--- a/benchmarks/named_routes
+++ b/benchmarks/named_routes
@@ -28,7 +28,7 @@ Benchmark.bm(50) do |b|
   app    = Rack::MockRequest.new(router)
 
   $named_routes.each do |(name, _)|
-    eval "#{ Hanami::Utils::String.new(name).classify } = Class.new($controller)"
+    eval "#{ Hanami::Utils::String.classify(name) } = Class.new($controller)"
   end
 
   b.report 'generating named routes (class endpoints)' do
@@ -60,7 +60,7 @@ Benchmark.bm(50) do |b|
   end
 
   $lazy.each do |(name, _)|
-    eval "#{ Hanami::Utils::String.new(name).classify } = Class.new($controller)"
+    eval "#{ Hanami::Utils::String.classify(name) } = Class.new($controller)"
   end
 
   b.report 'recognizing routes (lazy endpoints)' do

--- a/benchmarks/resource
+++ b/benchmarks/resource
@@ -33,7 +33,7 @@ Benchmark.bm(50) do |b|
   end
 
   $lazy.each do |w|
-    eval "#{ Hanami::Utils::String.new(w).classify }Controller = Class.new($resource_controller)"
+    eval "#{ Hanami::Utils::String.classify(w) }Controller = Class.new($resource_controller)"
   end
 
   b.report 'recognizing routes (lazy endpoints)' do

--- a/benchmarks/resources
+++ b/benchmarks/resources
@@ -40,7 +40,7 @@ Benchmark.bm(50) do |b|
   end
 
   $lazy.each do |w|
-    eval "#{ Hanami::Utils::String.new(w).classify }Controller = Class.new($resources_controller)"
+    eval "#{ Hanami::Utils::String.classify(w) }Controller = Class.new($resources_controller)"
   end
 
   b.report 'recognizing resources (lazy endpoints)' do

--- a/benchmarks/routes
+++ b/benchmarks/routes
@@ -28,7 +28,7 @@ Benchmark.bm(50) do |b|
   app    = Rack::MockRequest.new(router)
 
   $routes.each do |route|
-    eval "#{ Hanami::Utils::String.new(route).classify } = Class.new($controller)"
+    eval "#{ Hanami::Utils::String.classify(route) } = Class.new($controller)"
   end
 
   b.report 'generating routes (class endpoints)' do
@@ -56,7 +56,7 @@ Benchmark.bm(50) do |b|
   end
 
   $lazy.each do |route|
-    eval "#{ Hanami::Utils::String.new(route).classify } = Class.new($controller)"
+    eval "#{ Hanami::Utils::String.classify(route) } = Class.new($controller)"
   end
 
   b.report 'recognizing routes (lazy endpoints)' do

--- a/benchmarks/utils.rb
+++ b/benchmarks/utils.rb
@@ -46,11 +46,11 @@ $named_routes = $named_routes.map do |r|
 end
 
 $resource.each do |w|
-  eval "#{ Hanami::Utils::String.new(w).classify }Controller = Class.new($resource_controller)"
+  eval "#{ Hanami::Utils::String.classify(w) }Controller = Class.new($resource_controller)"
 end
 
 $resources.each do |w|
-  eval "#{ Hanami::Utils::String.new(w).classify }Controller = Class.new($resources_controller)"
+  eval "#{ Hanami::Utils::String.classify(w) }Controller = Class.new($resources_controller)"
 end
 
 GC.start


### PR DESCRIPTION
As a result of this https://github.com/hanami/utils/issues/259, the instance methods are here replaced by the class methods on the `develop` branch.