### PR TITLE
change Middleware to be a class not a module

### DIFF
--- a/lib/hanami/middleware/body_parser.rb
+++ b/lib/hanami/middleware/body_parser.rb
@@ -2,7 +2,7 @@ require 'hanami/middleware/body_parser/parser'
 require 'hanami/utils/hash'
 
 module Hanami
-  module Middleware
+  class Middleware
     # @since 1.3.0
     # @api private
     class BodyParser

--- a/lib/hanami/middleware/body_parser/json_parser.rb
+++ b/lib/hanami/middleware/body_parser/json_parser.rb
@@ -1,7 +1,7 @@
 require 'hanami/utils/json'
 
 module Hanami
-  module Middleware
+  class Middleware
     class BodyParser
       # @since 1.3.0
       # @api private

--- a/lib/hanami/middleware/body_parser/parser.rb
+++ b/lib/hanami/middleware/body_parser/parser.rb
@@ -3,7 +3,7 @@ require 'hanami/utils/string'
 require 'hanami/routing/parsing/parser'
 
 module Hanami
-  module Middleware
+  class Middleware
     class BodyParser
       # Body parsing error
       # This is raised when parser fails to parse the body


### PR DESCRIPTION
When updating the `hanami` project to use the new router middleware for parsing the body, I got an error:

```
Failure/Error: require 'hanami/middleware/body_parser'

TypeError: Middleware is not a module
```

I understand is because in the hanami project there is already a `Hanami::Middleware` namespace and  `Middleware` is a class, not a module. 

https://github.com/hanami/hanami/blob/master/lib/hanami/middleware.rb#L9

This PR changes that.