### PR TITLE
Skip attempting to parse unknown types in BodyParser middleware

### DIFF
--- a/lib/hanami/middleware/body_parser.rb
+++ b/lib/hanami/middleware/body_parser.rb
@@ -37,32 +37,29 @@ module Hanami
         body = env[RACK_INPUT].read
         return @app.call(env) if body.empty?
 
-        env[RACK_INPUT].rewind    # somebody might try to read this stream
+        env[RACK_INPUT].rewind # somebody might try to read this stream
 
-        env[ROUTER_PARAMS] ||= {} # prepare params
-        env[ROUTER_PARSED_BODY] = _parse(env, body)
-        env[ROUTER_PARAMS]      = _symbolize(env[ROUTER_PARSED_BODY]).merge(env[ROUTER_PARAMS])
+        if (parser = @parsers[media_type(env)])
+          env[ROUTER_PARSED_BODY] = parser.parse(body)
+          env[ROUTER_PARAMS] = _symbolize(env[ROUTER_PARSED_BODY])
+        end
 
         @app.call(env)
       end
 
       private
 
-      def build_parsers(parsers)
-        result  = Hash.new
-        args    = Array(parsers)
-        return result if args.empty?
+      def build_parsers(parser_names)
+        parser_names = Array(parser_names)
+        return {} if parser_names.empty?
 
-        args.each do |arg|
-          parser = Parser.for(arg)
+        parser_names.each_with_object({}) { |name, parsers|
+          parser = Parser.for(name)
 
           parser.mime_types.each do |mime|
-            result[mime] = parser
+            parsers[mime] = parser
           end
-        end
-
-        result.default = Parser.new
-        result
+        }
       end
 
       # @api private

--- a/spec/integration/hanami/middleware/body_parser/parser_spec.rb
+++ b/spec/integration/hanami/middleware/body_parser/parser_spec.rb
@@ -3,23 +3,26 @@ require 'rack/mock'
 
 RSpec.describe Hanami::Middleware::BodyParser::Parser do
   describe 'JSON parser'do
+    subject(:env) {
+      Rack::MockRequest.env_for('/', method: 'POST', 'CONTENT_TYPE' => content_type, input: body).tap do |env|
+        middleware.(env)
+      end
+    }
+
     let(:app) { -> (env) { [200, {}, "app"] } }
     let(:middleware) { Hanami::Middleware::BodyParser.new(app, [:json]) }
-    let(:env) { Rack::MockRequest.env_for('/', method: 'POST', 'CONTENT_TYPE' => content_type, input: body) }
     let(:body)         { '' }
     let(:content_type) { '' }
 
-    describe 'and a JSON request' do
+    describe 'JSON request' do
       let(:body)         { %({"attribute":"ok"}) }
       let(:content_type) { 'application/json' }
 
       it "parses params from body" do
-        middleware.call(env)
         expect(env['router.params']).to eq(attribute: "ok")
       end
 
       it "stores parsed body" do
-        middleware.call(env)
         expect(env['router.parsed_body']).to eq('attribute' => "ok")
       end
 
@@ -27,12 +30,10 @@ RSpec.describe Hanami::Middleware::BodyParser::Parser do
         let(:body) { %(["foo"]) }
 
         it "parses params from body" do
-          middleware.call(env)
           expect(env['router.params']).to eq("_" => ["foo"])
         end
 
         it "stores parsed body" do
-           middleware.call(env)
           expect(env['router.parsed_body']).to eq(["foo"])
         end
       end
@@ -40,22 +41,20 @@ RSpec.describe Hanami::Middleware::BodyParser::Parser do
       describe 'with malformed json' do
         let(:body) { %({"hanami":"ok" "attribute":"ok"}) }
         it 'raises an exception' do
-          expect { middleware.call(env) }.to raise_error(Hanami::Middleware::BodyParser::BodyParsingError)
+          expect { env }.to raise_error(Hanami::Middleware::BodyParser::BodyParsingError)
         end
       end
     end
 
-    describe 'and a JSON API request' do
+    describe 'JSON API request' do
       let(:body)         { %({"data": {"attribute":"ok"}}) }
       let(:content_type) { 'application/vnd.api+json' }
 
       it "parses params from body" do
-        middleware.call(env)
         expect(env['router.params']).to eq(data: { attribute: "ok" })
       end
 
       it "stores parsed body" do
-        middleware.call(env)
         expect(env['router.parsed_body']).to eq('data' => { 'attribute' => "ok" })
       end
 
@@ -63,17 +62,27 @@ RSpec.describe Hanami::Middleware::BodyParser::Parser do
         let(:body) {  %({"hanami":"ok" "attribute":"ok"}) }
 
         it 'raises an exception' do
-          expect { middleware.call(env) }.to raise_error(Hanami::Middleware::BodyParser::BodyParsingError)
+          expect { env }.to raise_error(Hanami::Middleware::BodyParser::BodyParsingError)
         end
       end
     end
 
-    describe 'and a non-JSON request' do
+    describe 'request with unknown content type' do
       let(:body)         { %(<element>ok</element>) }
       let(:content_type) { 'application/xml' }
 
-      it "returns the app as it is" do
-        expect(middleware.call(env)).to eq(app.(env))
+      it 'does not parse body params' do
+        expect(env.keys).not_to include('router.parsed_body')
+        expect(env.keys).not_to include('router.params')
+      end
+    end
+
+    describe 'request without content type' do
+      let(:body) { 'hanami=ok' }
+
+      it 'does not parse body params' do
+        expect(env.keys).not_to include('router.parsed_body')
+        expect(env.keys).not_to include('router.params')
       end
     end
   end


### PR DESCRIPTION
This is a narrowed-down PR based on the work I did in #180, focusing on the bug fix only, and leaving the refactoring work to be addressed in a separate follow-up PR.

This PR resolves #179. Now, when a `BodyParser` middleware is loaded, and the request’s content type does not match any of the loaded parser, it does not attempt to parse and symbolize the body. This ensures there will be no unexpected content in the resulting request env hash.

To make this concrete, given a `BodyParser` loaded, with `:json` as its only configured content type, when an ordinary x-www-form-urlencoded request comes through, it's body will _not_ be parsed, allowing Rack to parse it properly later on. This means we end up with params like this:

```ruby
{:hanami => "ok"}
```

And not like this:

```ruby
{:hanami => "ok", :_ => "hamami=ok"}
```

More details of the bug this fixes are in #179.

@jodosha Hopefully this is focused enough for you to review and merge? Once this is merged I'll follow up with the refactoring PR.

---

Fixes https://github.com/hanami/router/issues/179