### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ require 'hanami/router'
 require 'hanami/middleware/body_parser'
 
 # See Hanami::Routing::Parsing::Parser
-class XmlParser < Hanami::Middleware::BodyParser::Parser
+class XmlParser
   def mime_types
     ['application/xml', 'text/xml']
   end

--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ require 'hanami/router'
 require 'hanami/middleware/body_parser'
 
 # See Hanami::Routing::Parsing::Parser
-class XmlParser
+class XmlParser < Hanami::Routing::Parsing::Parser
   def mime_types
     ['application/xml', 'text/xml']
   end


### PR DESCRIPTION
Custom parser example is incorrect - there is no class `Hanami::Middleware::BodyParser::Parser`.

Custom parser classes don't need to extend any class - they can be POROs.