### PR TITLE
Ensure scoped root to not be added as trailing slash

### DIFF
--- a/lib/hanami/router/prefix.rb
+++ b/lib/hanami/router/prefix.rb
@@ -57,6 +57,8 @@ module Hanami
       # @since 2.0.0
       # @api private
       def _join(path)
+        return @prefix if path == DEFAULT_SEPARATOR
+
         (@prefix + DEFAULT_SEPARATOR + path)
           .gsub(DOUBLE_DEFAULT_SEPARATOR_REGEXP, DEFAULT_SEPARATOR)
       end

--- a/spec/integration/hanami/router/mount_spec.rb
+++ b/spec/integration/hanami/router/mount_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hanami::Router do
       mount Api::App.new,                  at: "/api"
       mount Backend::App,                  at: "/backend"
       mount ->(*) { [200, { "Content-Length" => "4" }, ["proc"]] }, at: "/proc"
+      mount ->(*) { [200, { "Content-Length" => "8" }, ["trailing"]] }, at: "/trailing/"
     end
   end
 
@@ -22,6 +23,10 @@ RSpec.describe Hanami::Router do
 
     it "accepts for a proc endpoint" do
       expect(app.request(verb.upcase, "/proc", lint: true).body).to eq(body_for("proc", verb))
+    end
+
+    it "accepts for a route using trailing slash" do
+      expect(app.request(verb.upcase, "/trailing/", lint: true).body).to eq(body_for("trailing", verb))
     end
 
     it "accepts sub paths when is requested" do

--- a/spec/integration/hanami/router/routing_spec.rb
+++ b/spec/integration/hanami/router/routing_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe Hanami::Router do
           r = response
 
           described_class.new do
+            __send__ verb, "/",                     to: ->(*) { r }
             __send__ verb, "/hanami",               to: ->(*) { r }
+            __send__ verb, "/trailing/",            to: ->(*) { r }
             __send__ verb, "/hanami/:id",           to: ->(*) { r }
             __send__ verb, "/hanami/:id(.:format)", to: ->(*) { r }
             __send__ verb, "/hanami/*glob",         to: ->(*) { r }
@@ -24,6 +26,22 @@ RSpec.describe Hanami::Router do
         let(:app) { Rack::MockRequest.new(router) }
 
         context "path recognition" do
+          context "root trailing slash" do
+            let(:response) { Rack::MockResponse.new(200, { "Content-Length" => "14" }, "Trailing root!") }
+
+            it "recognizes" do
+              expect(app.request(verb.upcase, "/", lint: true)).to eq_response(response)
+            end
+          end
+
+          context "trailing slash" do
+            let(:response) { Rack::MockResponse.new(200, { "Content-Length" => "9" }, "Trailing!") }
+
+            it "recognizes" do
+              expect(app.request(verb.upcase, "/trailing/", lint: true)).to eq_response(response)
+            end
+          end
+
           context "fixed string" do
             let(:response) { Rack::MockResponse.new(200, { "Content-Length" => "6" }, "Fixed!") }
 

--- a/spec/integration/hanami/router/scope_spec.rb
+++ b/spec/integration/hanami/router/scope_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe Hanami::Router do
       expect(app.request("OPTIONS", "/trees/cherry", lint: true).body).to eq("Cherry (OPTIONS)!")
     end
 
+    it "allows trailing slash" do
+      router = described_class.new do
+        scope "trees/" do
+          root to: ->(*) { [200, {}, ["Trees (GET)!"]] }
+        end
+      end
+
+      app = Rack::MockRequest.new(router)
+
+      expect(app.request("GET", "/trees/", lint: true).body).to eq("Trees (GET)!")
+    end
+
     context "nested" do
       it "defines HTTP methods correctly" do
         router = described_class.new do

--- a/spec/integration/hanami/router/scope_spec.rb
+++ b/spec/integration/hanami/router/scope_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Hanami::Router do
     it "recognizes get path" do
       router = described_class.new do
         scope "trees" do
+          root               to: ->(*) { [200, {}, ["Trees (GET)!"]] }
           get     "/cherry", to: ->(*) { [200, {}, ["Cherry (GET)!"]] }
           post    "/cherry", to: ->(*) { [200, {}, ["Cherry (POST)!"]] }
           put     "/cherry", to: ->(*) { [200, {}, ["Cherry (PUT)!"]] }
@@ -21,6 +22,7 @@ RSpec.describe Hanami::Router do
 
       app = Rack::MockRequest.new(router)
 
+      expect(app.request("GET", "/trees", lint: true).body).to eq("Trees (GET)!")
       expect(app.request("GET", "/trees/cherry", lint: true).body).to eq("Cherry (GET)!")
       expect(app.request("POST", "/trees/cherry", lint: true).body).to eq("Cherry (POST)!")
       expect(app.request("PUT", "/trees/cherry", lint: true).body).to eq("Cherry (PUT)!")


### PR DESCRIPTION
Given the following routes:

```ruby
Hanami::Router.new do
  scope "foo" do
    root to: ->(*) { [200, {}, ["Hello"]] }
  end
end
```

**Before:**

```
GET /foo # 404 Not Found
GET /foo/ # 200 OK
```

**After:**

```
GET /foo # 200 OK
GET /foo/ # 404 Not Found
```

---

Ref hanami/api#8