### PR TITLE
Ensure to not accidentally cache response headers for HTTP 404 and 405

### DIFF
--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -666,7 +666,7 @@ module Hanami
           url = path(env, params)
           return env_for(url, params, options) # rubocop:disable Style/RedundantReturn
         rescue Hanami::Router::InvalidRouteException
-          EMPTY_RACK_ENV
+          {} # Empty Rack env
         end
       else
         env
@@ -697,17 +697,9 @@ module Hanami
 
     # @since 2.0.0
     # @api private
-    EMPTY_PARAMS = {}.freeze
-
-    # @since 2.0.0
-    # @api private
-    EMPTY_RACK_ENV = {}.freeze
-
-    # @since 2.0.0
-    # @api private
     def lookup(env)
       endpoint = fixed(env)
-      return [endpoint, EMPTY_PARAMS.dup] if endpoint
+      return [endpoint, {}] if endpoint
 
       variable(env) || globbed(env) || mounted(env)
     end

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -666,7 +666,7 @@ module Hanami
           url = path(env, params)
           return env_for(url, params, options) # rubocop:disable Style/RedundantReturn
         rescue Hanami::Router::InvalidRouteException
-          EMPTY_RACK_ENV.dup
+          EMPTY_RACK_ENV
         end
       else
         env

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -631,13 +631,13 @@ module Hanami
     # @since 2.0.0
     # @api private
     def not_allowed(env)
-      (_not_allowed_fixed(env) || _not_allowed_variable(env)) and return NOT_ALLOWED
+      (_not_allowed_fixed(env) || _not_allowed_variable(env)) and return [405, { "Content-Length" => "11" }, ["Not Allowed"]]
     end
 
     # @since 2.0.0
     # @api private
     def not_found
-      NOT_FOUND
+      [404, { "Content-Length" => "9" }, ["Not Found"]]
     end
 
     protected
@@ -693,14 +693,6 @@ module Hanami
 
     # @since 2.0.0
     # @api private
-    NOT_FOUND = [404, { "Content-Length" => "9" }, ["Not Found"]].freeze
-
-    # @since 2.0.0
-    # @api private
-    NOT_ALLOWED = [405, { "Content-Length" => "11" }, ["Not Allowed"]].freeze
-
-    # @since 2.0.0
-    # @api private
     PARAMS = "router.params"
 
     # @since 2.0.0
@@ -715,7 +707,7 @@ module Hanami
     # @api private
     def lookup(env)
       endpoint = fixed(env)
-      return [endpoint, EMPTY_PARAMS] if endpoint
+      return [endpoint, EMPTY_PARAMS.dup] if endpoint
 
       variable(env) || globbed(env) || mounted(env)
     end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -3,6 +3,34 @@
 require "rexml/document"
 require "hanami/middleware/body_parser"
 
+require "securerandom"
+
+class RandomMiddleware
+  HEADER_PREFIX = "X-Random"
+  private_constant :HEADER_PREFIX
+
+  def self.headers_count(headers)
+    headers.find_all { |header, _| header.start_with?(HEADER_PREFIX) }.count
+  end
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+    headers["#{HEADER_PREFIX}-#{random}"] = "1"
+
+    [status, headers, body]
+  end
+
+  private
+
+  def random
+    SecureRandom.hex(8)
+  end
+end
+
 class MyMiddleware
   def call(*)
   end

--- a/spec/unit/hanami/router/not_allowed_spec.rb
+++ b/spec/unit/hanami/router/not_allowed_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Router do
+  subject do
+    described_class.new do
+      get "/", to: ->(*) { [200, { "Content-Length" => "4" }, ["root"]] }
+    end
+  end
+
+  describe "Not Allowed" do
+    it "it returns 405 when an endpoint can be found but the request uses the wrong HTTP verb" do
+      env = Rack::MockRequest.env_for("/", method: :post)
+      status, headers, body = subject.call(env)
+
+      expect(status).to  eq(405)
+      expect(headers).to eq("Content-Length" => "11")
+      expect(body).to    eq(["Not Allowed"])
+    end
+
+    it "doesn't cache previous 405 header responses" do
+      router = subject
+      app = Rack::Builder.new do
+        use RandomMiddleware
+        run router
+      end.to_app
+
+      # first request
+      request("/", app, :post)
+
+      # second request
+      request("/", app, :post)
+    end
+
+    private
+
+    def request(path, app, http_method = :get)
+      env = Rack::MockRequest.env_for(path, method: http_method)
+      status, headers, body = app.call(env)
+
+      random_headers_count = RandomMiddleware.headers_count(headers)
+      expect(status).to               eq(405)
+      expect(random_headers_count).to be(1)
+      expect(body).to                 eq(["Not Allowed"])
+    end
+  end
+end

--- a/spec/unit/hanami/router/not_found_spec.rb
+++ b/spec/unit/hanami/router/not_found_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Router do
+  subject { described_class.new {} }
+
+  describe "Not Found" do
+    it "it returns 404 when an endpoint cannot be found" do
+      env = Rack::MockRequest.env_for("/")
+      status, headers, body = subject.call(env)
+
+      expect(status).to  eq(404)
+      expect(headers).to eq("Content-Length" => "9")
+      expect(body).to    eq(["Not Found"])
+    end
+
+    it "doesn't cache previous 404 header responses" do
+      router = subject
+      app = Rack::Builder.new do
+        use RandomMiddleware
+        run router
+      end.to_app
+
+      # first request
+      request("/", app)
+
+      # second request
+      request("/", app)
+    end
+
+    private
+
+    def request(path, app, http_method = :get)
+      env = Rack::MockRequest.env_for(path, method: http_method)
+      status, headers, body = app.call(env)
+
+      random_headers_count = RandomMiddleware.headers_count(headers)
+      expect(status).to               eq(404)
+      expect(random_headers_count).to be(1)
+      expect(body).to                 eq(["Not Found"])
+    end
+  end
+end


### PR DESCRIPTION
## Bug

We internally used constants to store serialized Rack responses for HTTP 404 and 405.

```ruby
NOT_FOUND = [404, { "Content-Length" => "9" }, ["Not Found"]].freeze
NOT_ALLOWED = [405, { "Content-Length" => "11" }, ["Not Allowed"]].freeze
```

## Problems

### Problem 1: forgot to dup

In case of 404, the method was:

```ruby
def not_found
  NOT_FOUND
end
```

It was returning the constant, **without duping**. When the Rack middleware were modifying the response headers the second element of the `NOT_FOUND` constant was **modified**.

The following 404 response were receiving the same headers of the first request. 😱 
It was accidentally caching the values because Hashes in Ruby are passed by reference. So the constant was **mutated** 🙀 

### Problem 2: lack of deep freeze

To prevent the _escaped_ (see Java Concurrency in Practice book) reference to be accidentally mutated we used to freeze the constant.

But because `Object#freeze` doesn't freeze inner objects, the headers hash of `NOT_FOUND` was still mutable.

---

Two stupid mistakes of mine 🤦 

## Fix

The fix is simple: don't use constants.

The implementation of these methods just return inline values, so they can be safely mutated.

---

## Performance

I discovered that inline duped constants are 1.83x slower than inline values.

```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true

require "benchmark/ips"

EMPTY_RACK_ENV = {}.freeze

Benchmark.ips do |x|
  x.report("const") { env = EMPTY_RACK_ENV.dup; env["PATH_INFO"] = "/" }
  x.report("inline") { env = {}; env["PATH_INFO"] = "/" }
  x.compare!
end

__END__

Results:

Warming up --------------------------------------
               const   369.253k i/100ms
              inline   676.286k i/100ms
Calculating -------------------------------------
               const      3.672M (± 2.5%) i/s -     18.463M in   5.031615s
              inline      6.718M (± 7.6%) i/s -     33.814M in   5.068016s

Comparison:
              inline:  6718490.2 i/s
               const:  3671607.2 i/s - 1.83x  (± 0.00) slower

Ruby:

    ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-darwin16]

Hardware:

    Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro12,1
      Processor Name: Intel Core i7
      Processor Speed: 3,1 GHz
      Number of Processors: 1
      Total Number of Cores: 2
      L2 Cache (per Core): 256 KB
      L3 Cache: 4 MB
      Memory: 16 GB
      Boot ROM Version: 186.0.0.0.0
      SMC Version (system): 2.28f7

Software:

    System Software Overview:

      System Version: macOS 10.12.6 (16G2136)
      Kernel Version: Darwin 16.7.0
      Time since boot: 4 days 50 minutes
```