### PR TITLE
`Hanami::Router#initialize` do not yield block if not given

### DIFF
--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -71,7 +71,7 @@ module Hanami
       @variable = {}
       @globbed = {}
       @mounted = {}
-      instance_eval(&blk)
+      instance_eval(&blk) if blk
     end
 
     # Resolve the given Rack env to a registered endpoint and invokes it.

--- a/spec/unit/hanami/router/new_spec.rb
+++ b/spec/unit/hanami/router/new_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Hanami::Router do
       end
     end
 
+    it "returns instance of Hanami::Router" do
+      router = Hanami::Router.new
+      expect(router).to be_instance_of(Hanami::Router)
+    end
+
     it "returns instance of Hanami::Router with empty block" do
       router = Hanami::Router.new {}
       expect(router).to be_instance_of(Hanami::Router)


### PR DESCRIPTION
Allow `Hanami::Router` to be initialized without passing a block. This is useful when the router is assigned to a class variable and the class exposes a DSL to add routes, like in the case of `hanami-api`.