### PR TITLE
Add not_found option

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,13 @@ router = Hanami::Router.new
 router.call(Rack::MockRequest.env_for("/unknown")).status # => 404
 ```
 
+### Explicit Not Found:
+
+```ruby
+router = Hanami::Router.new(default_app: ->(_) { [499, {}, []]})
+router.call(Rack::MockRequest.env_for("/unknown")).status # => 499
+```
+
 ### Body Parsers
 
 Rack ignores request bodies unless they come from a form submission.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ router.call(Rack::MockRequest.env_for("/unknown")).status # => 404
 ### Explicit Not Found:
 
 ```ruby
-router = Hanami::Router.new(default_app: ->(_) { [499, {}, []]})
+router = Hanami::Router.new(not_found: ->(_) { [499, {}, []]})
 router.call(Rack::MockRequest.env_for("/unknown")).status # => 499
 ```
 

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -17,12 +17,6 @@ module Hanami
     require "hanami/router/block"
     require "hanami/router/url_helpers"
 
-    # Default response when no route was matched
-    #
-    # @api private
-    # @since 2.0.0
-    NOT_FOUND = ->(_) { [404, { "Content-Length" => "9" }, ["Not Found"]] }.freeze
-
     # URL helpers for other Hanami integrations
     #
     # @api private
@@ -702,6 +696,12 @@ module Hanami
     # @since 2.0.0
     # @api private
     PARAMS = "router.params"
+    
+    # Default response when no route was matched
+    #
+    # @api private
+    # @since 2.0.0
+    NOT_FOUND = ->(*) { [404, { "Content-Length" => "9" }, ["Not Found"]] }.freeze
 
     # @since 2.0.0
     # @api private

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -48,6 +48,7 @@ module Hanami
     #   is deployed
     # @param resolver [#call(path, to)] a resolver for route entpoints
     # @param block_context [Hanami::Router::Block::Context)
+    # @param default_app [#call(env)] default handler when route is not matched
     # @param blk [Proc] the route definitions
     #
     # @since 0.1.0
@@ -60,13 +61,14 @@ module Hanami
     #   Hanami::Router.new do
     #     get "/", to: ->(*) { [200, {}, ["OK"]] }
     #   end
-    def initialize(base_url: DEFAULT_BASE_URL, prefix: DEFAULT_PREFIX, resolver: DEFAULT_RESOLVER, block_context: nil, &blk)
+    def initialize(base_url: DEFAULT_BASE_URL, prefix: DEFAULT_PREFIX, resolver: DEFAULT_RESOLVER, block_context: nil, default_app: not_found, &blk)
       # TODO: verify if Prefix can handle both name and path prefix
       @path_prefix = Prefix.new(prefix)
       @name_prefix = Prefix.new("")
       @url_helpers = UrlHelpers.new(base_url)
       @resolver = resolver
       @block_context = block_context
+      @default_app = default_app
       @fixed = {}
       @variable = {}
       @globbed = {}
@@ -86,7 +88,7 @@ module Hanami
 
       unless endpoint
         return not_allowed(env) ||
-               not_found
+               @default_app.call(env)
       end
 
       endpoint.call(
@@ -637,7 +639,7 @@ module Hanami
     # @since 2.0.0
     # @api private
     def not_found
-      [404, { "Content-Length" => "9" }, ["Not Found"]]
+      ->(_) { [404, { "Content-Length" => "9" }, ["Not Found"]] }
     end
 
     protected

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -48,7 +48,7 @@ module Hanami
     #   is deployed
     # @param resolver [#call(path, to)] a resolver for route entpoints
     # @param block_context [Hanami::Router::Block::Context)
-    # @param default_app [#call(env)] default handler when route is not matched
+    # @param not_found [#call(env)] default handler when route is not matched
     # @param blk [Proc] the route definitions
     #
     # @since 0.1.0

--- a/spec/unit/hanami/router/not_found_spec.rb
+++ b/spec/unit/hanami/router/not_found_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Hanami::Router do
       request("/", app)
     end
 
-    context "with default_app option" do
-      let(:not_found) { ->(_env) { [499, { "Content-Type" => "application/json" }, [JSON.dump({ error: "not_found" })]] } }
+    context "with not_found option" do
+      let(:not_found) { ->(*) { [499, { "Content-Type" => "application/json" }, [JSON.dump({ error: "not_found" })]] } }
       subject { described_class.new(not_found: not_found) {} }
 
       it "uses it" do

--- a/spec/unit/hanami/router/not_found_spec.rb
+++ b/spec/unit/hanami/router/not_found_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe Hanami::Router do
       request("/", app)
     end
 
+    context "with default_app option" do
+      let(:default_app) { ->(_env) { [499, { "Content-Type" => "application/json" }, [JSON.dump({ error: "not_found" })]] } }
+      subject { described_class.new(default_app: default_app) {} }
+
+      it "uses it" do
+        env = Rack::MockRequest.env_for("/")
+        status, headers, body = subject.call(env)
+
+        expect(status).to eq(499)
+        expect(headers).to eq("Content-Type" => "application/json")
+        expect(body).to eq(['{"error":"not_found"}'])
+      end
+    end
+
     private
 
     def request(path, app, http_method = :get)

--- a/spec/unit/hanami/router/not_found_spec.rb
+++ b/spec/unit/hanami/router/not_found_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Hanami::Router do
     end
 
     context "with default_app option" do
-      let(:default_app) { ->(_env) { [499, { "Content-Type" => "application/json" }, [JSON.dump({ error: "not_found" })]] } }
-      subject { described_class.new(default_app: default_app) {} }
+      let(:not_found) { ->(_env) { [499, { "Content-Type" => "application/json" }, [JSON.dump({ error: "not_found" })]] } }
+      subject { described_class.new(not_found: not_found) {} }
 
       it "uses it" do
         env = Rack::MockRequest.env_for("/")


### PR DESCRIPTION
This adds `not_found` option which was present in 1.x and allowed to specify custom handler for when route was not recognized.

~~It was a bit tempting to choose better name (`default_handler` perhaps?), but I decided to stick with original name for this PR.~~