### PR TITLE
Allow creation of namespaced router without block

### DIFF
--- a/lib/hanami/routing/namespace.rb
+++ b/lib/hanami/routing/namespace.rb
@@ -18,7 +18,7 @@ module Hanami
         @router = router
         @name   = Utils::PathPrefix.new(name)
         __setobj__(@router)
-        instance_eval(&blk)
+        instance_eval(&blk) if blk
       end
 
       # @api private

--- a/spec/integration/hanami/router/namespace_spec.rb
+++ b/spec/integration/hanami/router/namespace_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe Hanami::Router do
   end
 
   describe '#namespace' do
+    it 'does not require a block' do
+      subrouter = @router.namespace 'trees'
+      subrouter.get '/plane-tree', to: ->(_env) { [200, {}, ['Trees (GET)!']] }
+
+      expect(@app.request('GET', '/trees/plane-tree', lint: true).body).to eq('Trees (GET)!')
+    end
+
     it 'recognizes get path' do
       @router.namespace 'trees' do
         get '/plane-tree', to: ->(_env) { [200, {}, ['Trees (GET)!']] }


### PR DESCRIPTION
Removes the requirement of a blck being provided during the
creation of namespaced routers

For example:

router = Hanami::Router.new
subrouter = router.namespace 'admin'
subrouter.get '/sample', to: Admin::Sample