### PR TITLE
Fixed long path etc router inspect output

### DIFF
--- a/lib/hanami/router/inspector.rb
+++ b/lib/hanami/router/inspector.rb
@@ -67,16 +67,22 @@ module Hanami
 
       # @api private
       # @since 2.0.0
+      EXTRA_SEPERATOR = " "
+      private_constant :EXTRA_SEPERATOR
+
+      # @api private
+      # @since 2.0.0
       def inspect_route(route)
         return EMPTY_ROUTE if route.fetch(:http_method) == "HEAD"
 
         result = route.fetch(:http_method).to_s.ljust(SMALL_STRING_JUSTIFY_AMOUNT)
-        result += route.fetch(:path).ljust(LARGE_STRING_JUSTIFY_AMOUNT)
+        result += route.fetch(:path).ljust(LARGE_STRING_JUSTIFY_AMOUNT) + EXTRA_SEPERATOR
         result += inspect_to(route.fetch(:to)).ljust(LARGE_STRING_JUSTIFY_AMOUNT)
-        result += "as #{route.fetch(:as).inspect}".ljust(MEDIUM_STRING_JUSTIFY_AMOUNT) if route.fetch(:as, nil)
+        result += "#{EXTRA_SEPERATOR}as #{route.fetch(:as).inspect}".ljust(MEDIUM_STRING_JUSTIFY_AMOUNT) if route[:as]
 
         unless route.fetch(:constraints, {}).empty?
-          result += "(#{inspect_constraints(route.fetch(:constraints))})".ljust(EXTRA_LARGE_STRING_JUSTIFY_AMOUNT)
+          result += "#{EXTRA_SEPERATOR}(#{inspect_constraints(route.fetch(:constraints))})" \
+            .ljust(EXTRA_LARGE_STRING_JUSTIFY_AMOUNT)
         end
 
         result

--- a/spec/unit/hanami/router/inspector_spec.rb
+++ b/spec/unit/hanami/router/inspector_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Hanami::Router::Inspector do
 
       it "returns inspected routes" do
         expected = [
-          "GET     /                             home#index                    as :root"
+          "GET     /                              home#index                     as :root"
         ]
 
         actual = subject.call(routes)

--- a/spec/unit/hanami/router/to_inspect_spec.rb
+++ b/spec/unit/hanami/router/to_inspect_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe Hanami::Router do
           get "/users", to: ->(*) {}
         end
 
+        # LOTS OF LONG STUFF
+        get "/very/very/long/url/to/:project_id/:item_id", \
+            to: "my_wonderful_app/controllers/super_duper_controller#action", \
+            as: :long_name_for_long_long_url, \
+            id: /\d+/, project_id: /\d+/
+
         # MOUNT
         mount App.new, at: "/app"
       end
@@ -72,28 +78,30 @@ RSpec.describe Hanami::Router do
 
     it "returns inspectable routes" do
       expected = [
-        "GET     /                             home#index                    as :root",
-        "GET     /foo                          controller#action",
-        "POST    /foo                          controller#action",
-        "PATCH   /foo                          controller#action",
-        "PUT     /foo                          controller#action",
-        "DELETE  /foo                          controller#action",
-        "TRACE   /foo                          controller#action",
-        "OPTIONS /foo                          controller#action",
-        "LINK    /foo                          controller#action",
-        "UNLINK  /foo                          controller#action",
-        "GET     /login                        sessions#new                  as :login",
-        "GET     /constraints/:id/:keyword     constraints#show              (id: /\\d+/, keyword: /\\w+/)",
-        "GET     /block                        (block)",
-        "GET     /proc                         (proc)",
-        "GET     /class                        Endpoint",
-        "GET     /object                       Endpoint",
-        "GET     /anonymous                    (class)",
-        "GET     /anonymous-object             (class)",
-        "GET     /redirect                     /redirect_destination (HTTP 301)",
-        "GET     /redirect-temporary           /redirect_destination (HTTP 302)",
-        "GET     /v1/users                     (proc)",
-        "*       /app                          App"
+        "GET     /                              home#index                     as :root",
+        "GET     /foo                           controller#action",
+        "POST    /foo                           controller#action",
+        "PATCH   /foo                           controller#action",
+        "PUT     /foo                           controller#action",
+        "DELETE  /foo                           controller#action",
+        "TRACE   /foo                           controller#action",
+        "OPTIONS /foo                           controller#action",
+        "LINK    /foo                           controller#action",
+        "UNLINK  /foo                           controller#action",
+        "GET     /login                         sessions#new                   as :login",
+        "GET     /constraints/:id/:keyword      constraints#show               (id: /\\d+/, keyword: /\\w+/)",
+        "GET     /block                         (block)",
+        "GET     /proc                          (proc)",
+        "GET     /class                         Endpoint",
+        "GET     /object                        Endpoint",
+        "GET     /anonymous                     (class)",
+        "GET     /anonymous-object              (class)",
+        "GET     /redirect                      /redirect_destination (HTTP 301)",
+        "GET     /redirect-temporary            /redirect_destination (HTTP 302)",
+        "GET     /v1/users                      (proc)",
+        "GET     /very/very/long/url/to/:project_id/:item_id my_wonderful_app/controllers/super_duper_controller#action " \
+                   "as :long_name_for_long_long_url (id: /\\d+/, project_id: /\\d+/)",
+        "*       /app                           App"
       ]
 
       actual = subject.to_inspect


### PR DESCRIPTION
When you have a long URL in router, then router inspection output won't have space separating fields.
In this Pull Requests contains a simple fix.

Let me know if I should change anything


EDIT:
Alternatively need to check each columns max length in order to adjust widths before printing