### PR TITLE
Hanami::API inspector compat

### DIFF
--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -15,6 +15,7 @@ module Hanami
     require "hanami/router/params"
     require "hanami/router/trie"
     require "hanami/router/block"
+    require "hanami/router/route"
     require "hanami/router/url_helpers"
 
     # URL helpers for other Hanami integrations
@@ -418,7 +419,9 @@ module Hanami
       prefix = Segment.fabricate(path, **constraints)
 
       @mounted[prefix] = @resolver.call(path, app)
-      @inspector.add_route({http_method: "*", path: at, to: app, constraints: constraints}) if inspect?
+      if inspect?
+        @inspector.add_route(Route.new(http_method: "*", path: at, to: app, constraints: constraints))
+      end
     end
 
     # Generate an relative URL for a specified named route.
@@ -756,7 +759,9 @@ module Hanami
       add_named_route(path, as, constraints) if as
 
       if inspect?
-        @inspector.add_route({http_method: http_method, path: path, to: to, as: as, constraints: constraints, blk: blk})
+        @inspector.add_route(
+          Route.new(http_method: http_method, path: path, to: to, as: as, constraints: constraints, blk: blk)
+        )
       end
     end
 

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -82,7 +82,6 @@ module Hanami
       @mounted = {}
       @blk = blk
       @inspector = inspector
-      @routes = [] if inspect?
       instance_eval(&blk) if blk
     end
 
@@ -419,7 +418,7 @@ module Hanami
       prefix = Segment.fabricate(path, **constraints)
 
       @mounted[prefix] = @resolver.call(path, app)
-      @routes << {http_method: "*", path: at, to: app, constraints: constraints} if inspect?
+      @inspector.add_route({http_method: "*", path: at, to: app, constraints: constraints}) if inspect?
     end
 
     # Generate an relative URL for a specified named route.
@@ -610,9 +609,9 @@ module Hanami
       require "hanami/router/inspector"
 
       inspector = Inspector.new
-      router = with(inspector: inspector)
+      with(inspector: inspector)
 
-      inspector.call(router.routes)
+      inspector.call
     end
 
     # @since 2.0.0
@@ -757,7 +756,7 @@ module Hanami
       add_named_route(path, as, constraints) if as
 
       if inspect?
-        @routes << {http_method: http_method, path: path, to: to, as: as, constraints: constraints, blk: blk}
+        @inspector.add_route({http_method: http_method, path: path, to: to, as: as, constraints: constraints, blk: blk})
       end
     end
 

--- a/lib/hanami/router/inspector.rb
+++ b/lib/hanami/router/inspector.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/router/redirect"
-require "hanami/router/block"
-
 module Hanami
   class Router
     # Routes inspector
@@ -31,91 +28,13 @@ module Hanami
       # @api private
       # @since 2.0.0
       def call(*)
-        @routes.map do |route|
-          inspect_route(route)
-        end.join(NEW_LINE)
+        @routes.map(&:to_inspect).join(NEW_LINE)
       end
-
-      private
 
       # @api private
       # @since 2.0.0
       NEW_LINE = $/
       private_constant :NEW_LINE
-
-      # @api private
-      # @since 2.0.0
-      EMPTY_ROUTE = ""
-      private_constant :EMPTY_ROUTE
-
-      # @api private
-      # @since 2.0.0
-      ROUTE_CONSTRAINT_SEPARATOR = ", "
-      private_constant :ROUTE_CONSTRAINT_SEPARATOR
-
-      # @api private
-      # @since 2.0.0
-      SMALL_STRING_JUSTIFY_AMOUNT = 8
-      private_constant :SMALL_STRING_JUSTIFY_AMOUNT
-
-      # @api private
-      # @since 2.0.0
-      MEDIUM_STRING_JUSTIFY_AMOUNT = 20
-      private_constant :MEDIUM_STRING_JUSTIFY_AMOUNT
-
-      # @api private
-      # @since 2.0.0
-      LARGE_STRING_JUSTIFY_AMOUNT = 30
-      private_constant :LARGE_STRING_JUSTIFY_AMOUNT
-
-      # @api private
-      # @since 2.0.0
-      EXTRA_LARGE_STRING_JUSTIFY_AMOUNT = 40
-      private_constant :EXTRA_LARGE_STRING_JUSTIFY_AMOUNT
-
-      # @api private
-      # @since 2.0.0
-      def inspect_route(route)
-        return EMPTY_ROUTE if route.fetch(:http_method) == "HEAD"
-
-        result = route.fetch(:http_method).to_s.ljust(SMALL_STRING_JUSTIFY_AMOUNT)
-        result += route.fetch(:path).ljust(LARGE_STRING_JUSTIFY_AMOUNT)
-        result += inspect_to(route.fetch(:to)).ljust(LARGE_STRING_JUSTIFY_AMOUNT)
-        result += "as #{route.fetch(:as).inspect}".ljust(MEDIUM_STRING_JUSTIFY_AMOUNT) if route.fetch(:as, nil)
-
-        unless route.fetch(:constraints, {}).empty?
-          result += "(#{inspect_constraints(route.fetch(:constraints))})".ljust(EXTRA_LARGE_STRING_JUSTIFY_AMOUNT)
-        end
-
-        result
-      end
-
-      # @api private
-      # @since 2.0.0
-      def inspect_to(to)
-        case to
-        when String
-          to
-        when Proc
-          "(proc)"
-        when Class
-          to.name || "(class)"
-        when Block
-          "(block)"
-        when Redirect
-          "#{to.destination} (HTTP #{to.code})"
-        else
-          inspect_to(to.class)
-        end
-      end
-
-      # @api private
-      # @since 2.0.0
-      def inspect_constraints(constraints)
-        constraints.map do |key, value|
-          "#{key}: #{value.inspect}"
-        end.join(ROUTE_CONSTRAINT_SEPARATOR)
-      end
     end
   end
 end

--- a/lib/hanami/router/inspector.rb
+++ b/lib/hanami/router/inspector.rb
@@ -12,8 +12,16 @@ module Hanami
     class Inspector
       # @api private
       # @since 2.0.0
-      def initialize
-        freeze
+      def initialize(routes: [])
+        @routes = routes
+      end
+
+      # @param route [Hash] serialized route
+      #
+      # @api private
+      # @since 2.0.0
+      def add_route(route)
+        @routes.push(route)
       end
 
       # @param routes [Array<Hash>] serialized routes
@@ -22,8 +30,8 @@ module Hanami
       #
       # @api private
       # @since 2.0.0
-      def call(routes)
-        routes.map do |route|
+      def call(*)
+        @routes.map do |route|
           inspect_route(route)
         end.join(NEW_LINE)
       end

--- a/lib/hanami/router/route.rb
+++ b/lib/hanami/router/route.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "hanami/router/redirect"
+require "hanami/router/block"
+
+module Hanami
+  class Router
+    class Route
+      # @api private
+      # @since 2.0.0
+      attr_reader :http_method
+
+      # @api private
+      # @since 2.0.0
+      attr_reader :path
+
+      # @api private
+      # @since 2.0.0
+      attr_reader :to
+
+      # @api private
+      # @since 2.0.0
+      attr_reader :as
+
+      # @api private
+      # @since 2.0.0
+      attr_reader :constraints
+
+      # @api private
+      # @since 2.0.0
+      def initialize(http_method:, path:, to:, as: nil, constraints: {}, blk: nil) # rubocop:disable Metrics/ParameterLists
+        @http_method = http_method
+        @path = path
+        @to = to
+        @as = as
+        @constraints = constraints
+        @blk = blk
+        freeze
+      end
+
+      # @api private
+      # @since 2.0.0
+      def to_inspect
+        return EMPTY_ROUTE if head?
+
+        result = http_method.to_s.ljust(SMALL_STRING_JUSTIFY_AMOUNT)
+        result += path.ljust(LARGE_STRING_JUSTIFY_AMOUNT)
+        result += inspect_to(to).ljust(LARGE_STRING_JUSTIFY_AMOUNT)
+        result += "as #{as.inspect}".ljust(MEDIUM_STRING_JUSTIFY_AMOUNT) if as
+
+        if constraints?
+          result += "(#{inspect_constraints(constraints)})".ljust(EXTRA_LARGE_STRING_JUSTIFY_AMOUNT)
+        end
+
+        result
+      end
+
+      private
+
+      # @api private
+      # @since 2.0.0
+      EMPTY_ROUTE = ""
+      private_constant :EMPTY_ROUTE
+
+      # @api private
+      # @since 2.0.0
+      ROUTE_CONSTRAINT_SEPARATOR = ", "
+      private_constant :ROUTE_CONSTRAINT_SEPARATOR
+
+      # @api private
+      # @since 2.0.0
+      SMALL_STRING_JUSTIFY_AMOUNT = 8
+      private_constant :SMALL_STRING_JUSTIFY_AMOUNT
+
+      # @api private
+      # @since 2.0.0
+      MEDIUM_STRING_JUSTIFY_AMOUNT = 20
+      private_constant :MEDIUM_STRING_JUSTIFY_AMOUNT
+
+      # @api private
+      # @since 2.0.0
+      LARGE_STRING_JUSTIFY_AMOUNT = 30
+      private_constant :LARGE_STRING_JUSTIFY_AMOUNT
+
+      # @api private
+      # @since 2.0.0
+      EXTRA_LARGE_STRING_JUSTIFY_AMOUNT = 40
+      private_constant :EXTRA_LARGE_STRING_JUSTIFY_AMOUNT
+
+      # @api private
+      # @since 2.0.0
+      def head?
+        http_method == "HEAD"
+      end
+
+      # @api private
+      # @since 2.0.0
+      def constraints?
+        constraints.any?
+      end
+
+      # @api private
+      # @since 2.0.0
+      def inspect_to(to)
+        case to
+        when String
+          to
+        when Proc
+          "(proc)"
+        when Class
+          to.name || "(class)"
+        when Block
+          "(block)"
+        when Redirect
+          "#{to.destination} (HTTP #{to.code})"
+        else
+          inspect_to(to.class)
+        end
+      end
+
+      # @api private
+      # @since 2.0.0
+      def inspect_constraints(constraints)
+        constraints.map do |key, value|
+          "#{key}: #{value.inspect}"
+        end.join(ROUTE_CONSTRAINT_SEPARATOR)
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/router/inspector_spec.rb
+++ b/spec/unit/hanami/router/inspector_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hanami::Router::Inspector do
 
   describe "#add_route" do
     it "adds a route to the inspector" do
-      subject.add_route({http_method: "GET", path: "/", to: "home#index"})
+      subject.add_route(Hanami::Router::Route.new(http_method: "GET", path: "/", to: "home#index"))
       expect(subject.call).to include("GET     /                             home#index")
     end
   end
@@ -28,7 +28,7 @@ RSpec.describe Hanami::Router::Inspector do
 
     context "with routes" do
       let(:routes) do
-        [{http_method: "GET", path: "/", to: "home#index", as: :root, constraints: {}, blk: nil}]
+        [Hanami::Router::Route.new(http_method: "GET", path: "/", to: "home#index", as: :root, constraints: {}, blk: nil)]
       end
 
       it "returns inspected routes" do

--- a/spec/unit/hanami/router/inspector_spec.rb
+++ b/spec/unit/hanami/router/inspector_spec.rb
@@ -3,19 +3,24 @@
 require "hanami/router/inspector"
 
 RSpec.describe Hanami::Router::Inspector do
-  subject { described_class.new }
+  subject { described_class.new(routes: routes) }
+  let(:routes) { [] }
 
   describe "#initialize" do
     it "returns a frozen instance of #{described_class}" do
       expect(subject).to be_kind_of(described_class)
-      expect(subject).to be_frozen
+    end
+  end
+
+  describe "#add_route" do
+    it "adds a route to the inspector" do
+      subject.add_route({http_method: "GET", path: "/", to: "home#index"})
+      expect(subject.call).to include("GET     /                             home#index")
     end
   end
 
   describe "#call" do
     context "no routes" do
-      let(:routes) { [] }
-
       it "returns an empty result" do
         expect(subject.call(routes)).to eq("")
       end
@@ -31,7 +36,7 @@ RSpec.describe Hanami::Router::Inspector do
           "GET     /                             home#index                    as :root"
         ]
 
-        actual = subject.call(routes)
+        actual = subject.call
         expected.each do |route|
           expect(actual).to include(route)
         end


### PR DESCRIPTION
## Enhancements

  * Ensure that the routes inspection is lazy, so the memory won't grow up unnecessary at the startup time when inspection isn't triggered.
  * Transform `Hanami::Router::Inspector` into a mutable data object (it was a _callable object_) to ensure Hanami::API can use it.
  * Introduce `Hanami::Router::Route` to resolve _data clump_ code smell.

---

Ref https://github.com/hanami/router/pull/208