### PR TITLE
Github Actions: Add Truffle Ruby to the build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           - "2.4"
           - "2.3"
           - "jruby"
+          - "truffleruby-head"
     steps:
       - uses: actions/checkout@v1
       - name: Install package dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - "2.4"
           - "2.3"
           - "jruby"
-          - "truffleruby-head"
+          - "truffleruby"
     steps:
       - uses: actions/checkout@v1
       - name: Install package dependencies
@@ -44,3 +44,4 @@ jobs:
         run: bundle install --jobs 4 --retry 3
       - name: Run all tests
         run: script/ci
+        continue-on-error: ${{ startsWith(matrix.ruby, 'truffleruby') }}


### PR DESCRIPTION
I was able to get the test suite passing locally using truffleruby+graalvm-21.1.0. Would be great to see gradual Hanami support for Truffle Ruby with its promising future for high performance Ruby.