### PR TITLE
Monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,3 @@ end
 
 gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git", branch: "main"
 gem "hanami-devtools",              require: false, git: "https://github.com/hanami/devtools.git", branch: "main"
-
-gem "dry-events", "~> 0.2"

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ end
 
 gem "hanami-utils", "~> 2.0.alpha", require: false, git: "https://github.com/hanami/utils.git", branch: "main"
 gem "hanami-devtools",              require: false, git: "https://github.com/hanami/devtools.git", branch: "main"
+
+gem "dry-events", "~> 0.2"

--- a/hanami-router.gemspec
+++ b/hanami-router.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rubocop", "0.91"
   spec.add_development_dependency "rubocop-performance", "1.8.1"
+
+  spec.add_development_dependency "dry-events", "~> 0.2"
 end

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -30,6 +30,10 @@ module Hanami
     # @since 2.0.0
     attr_reader :routes
 
+    # @api private
+    # @since 2.0.0
+    attr_reader :monitoring
+
     # Returns the given block as it is.
     #
     # @param blk [Proc] a set of route definitions
@@ -68,13 +72,14 @@ module Hanami
     #   Hanami::Router.new do
     #     get "/", to: ->(*) { [200, {}, ["OK"]] }
     #   end
-    def initialize(base_url: DEFAULT_BASE_URL, prefix: DEFAULT_PREFIX, resolver: DEFAULT_RESOLVER, not_found: NOT_FOUND, block_context: nil, inspector: nil, &blk) # rubocop:disable Layout/LineLength
+    def initialize(base_url: DEFAULT_BASE_URL, prefix: DEFAULT_PREFIX, resolver: DEFAULT_RESOLVER, monitoring: DEFAULT_MONITORING, not_found: NOT_FOUND, block_context: nil, inspector: nil, &blk) # rubocop:disable Layout/LineLength
       # TODO: verify if Prefix can handle both name and path prefix
       @path_prefix = Prefix.new(prefix)
       @name_prefix = Prefix.new("")
       @url_helpers = UrlHelpers.new(base_url)
       @base_url = base_url
       @resolver = resolver
+      @monitoring = monitoring
       @not_found = not_found
       @block_context = block_context
       @fixed = {}
@@ -94,7 +99,7 @@ module Hanami
     #
     # @since 0.1.0
     def call(env)
-      endpoint, params = lookup(env)
+      endpoint, params = monitoring.call { lookup(env) }
 
       unless endpoint
         return not_allowed(env) ||
@@ -726,6 +731,10 @@ module Hanami
     # @since 2.0.0
     # @api private
     PARAMS = "router.params"
+
+    # @since 2.0.0
+    # @api private
+    DEFAULT_MONITORING = ->(*, &blk) { blk.call }
 
     # Default response when no route was matched
     #

--- a/lib/hanami/router/monitoring.rb
+++ b/lib/hanami/router/monitoring.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "dry/events/publisher"
+
+module Hanami
+  class Router
+    # Router monitoring
+    #
+    # @api private
+    # @since 2.0.0
+    class Monitoring
+      # @api private
+      # @since 2.0.0
+      PREFIX = "hanami.monitoring.router"
+
+      # @api private
+      # @since 2.0.0
+      KEY = "#{PREFIX}.lookup"
+
+      include Dry::Events::Publisher[PREFIX]
+      register_event(KEY)
+
+      # @api private
+      # @since 2.0.0
+      def call
+        starting = now
+        result = yield
+
+        publish(KEY, elapsed: now - starting)
+        result
+      end
+
+      private
+
+      # @api private
+      # @since 2.0.0
+      def now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
+      end
+    end
+  end
+end

--- a/lib/hanami/router/monitoring.rb
+++ b/lib/hanami/router/monitoring.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require "dry/events/publisher"
+begin
+  require "dry/events/publisher"
+rescue LoadError
+  raise "`hanami/router/monitoring` requires `dry-events` gem, add it to your `Gemfile`."
+end
 
 module Hanami
   class Router

--- a/spec/integration/hanami/router/monitoring_spec.rb
+++ b/spec/integration/hanami/router/monitoring_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "hanami/router/monitoring"
+require "rack/request"
+
+RSpec.describe Hanami::Router do
+  subject do
+    described_class.new(monitoring: Hanami::Router::Monitoring.new) do
+      root { "Hello" }
+    end
+  end
+
+  let(:listener) do
+    Class.new do
+      attr_reader :events
+
+      def initialize
+        @events = []
+      end
+
+      def on_hanami_monitoring_router_lookup(event)
+        @events << event
+      end
+    end.new
+  end
+
+  it "monitors routes lookup and dispatch" do
+    subject.monitoring.subscribe(listener)
+
+    env = Rack::MockRequest.env_for("/", method: :get)
+    response = subject.call(env)
+
+    expect(response[0]).to be(200)
+    expect(response[2]).to eq(["Hello"])
+
+    expect(listener.events.count).to be(1) # lookup
+
+    event = listener.events[0]
+    expect(event.id).to eq(Hanami::Router::Monitoring::KEY)
+    expect(event.payload.keys).to match_array([:elapsed])
+  end
+end


### PR DESCRIPTION
## Feature

Introduce monitoring concept in `Hanami::Router`.

Added a new dependency for the router that can be specified via the `monitoring:` keyword argument for `Hanami::Router#initialize`.
The object must respond to `#call(*, &blk)`.

This PR ships with a default monitoring implementation based on `dry-events`.

```ruby
# Gemfile

gem "hanami-router"
gem "dry-events"
```

```ruby
require "hanami/router"
require "hanami/router/monitoring"

router = Hanami::Router.new(monitoring: Hanami::Router::Monitoring.new) do
  root { "Hello" }
end

router.subscribe("hanami.monitoring.router.lookup") do |event|
  puts "Router took #{event.payload.fetch(:elapsed)}ms to lookup"
end

router.call(env)
# => "Router took 0.005ms to lookup"
```