### PR TITLE
Extract formatter algorithm from the inspector

### DIFF
--- a/hanami-router.gemspec
+++ b/hanami-router.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -- lib/* CHANGELOG.md LICENSE.md README.md hanami-router.gemspec`.split($/)
   spec.executables   = []
-  spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ["lib"]
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.required_ruby_version = ">= 3.0"

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -27,7 +27,6 @@ module Hanami
 
     # Routes for inspection
     #
-    # @api private
     # @since 2.0.0
     attr_reader :routes
 
@@ -603,7 +602,7 @@ module Hanami
       )
     end
 
-    # Returns formatted routes
+    # Returns formatted routes with the default formatter
     #
     # @return [String] formatted routes
     #

--- a/lib/hanami/router/formatter/human_friendly.rb
+++ b/lib/hanami/router/formatter/human_friendly.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Router
+    # Renders a human friendly representation of the routes
+    #
+    # @api private
+    # @since 2.0.0
+    module Formatter
+      class HumanFriendly
+        # @api private
+        # @since 2.0.0
+        NEW_LINE = $/
+        private_constant :NEW_LINE
+
+        # @api private
+        # @since 2.0.0
+        EMPTY_ROUTE = ""
+        private_constant :EMPTY_ROUTE
+
+        # @api private
+        # @since 2.0.0
+        SMALL_STRING_JUSTIFY_AMOUNT = 8
+        private_constant :SMALL_STRING_JUSTIFY_AMOUNT
+
+        # @api private
+        # @since 2.0.0
+        MEDIUM_STRING_JUSTIFY_AMOUNT = 20
+        private_constant :MEDIUM_STRING_JUSTIFY_AMOUNT
+
+        # @api private
+        # @since 2.0.0
+        LARGE_STRING_JUSTIFY_AMOUNT = 30
+        private_constant :LARGE_STRING_JUSTIFY_AMOUNT
+
+        # @api private
+        # @since 2.0.0
+        EXTRA_LARGE_STRING_JUSTIFY_AMOUNT = 40
+        private_constant :EXTRA_LARGE_STRING_JUSTIFY_AMOUNT
+
+        # @api private
+        # @since 2.0.0
+        def call(routes)
+          routes.map(&method(:format_route)).join(NEW_LINE)
+        end
+
+        private
+
+        def format_route(route)
+          return EMPTY_ROUTE if route.head?
+
+          [
+            route.http_method.to_s.ljust(SMALL_STRING_JUSTIFY_AMOUNT),
+            route.path.ljust(LARGE_STRING_JUSTIFY_AMOUNT),
+            route.inspect_to(route.to).ljust(LARGE_STRING_JUSTIFY_AMOUNT),
+            route.as ? "as #{route.as.inspect}".ljust(MEDIUM_STRING_JUSTIFY_AMOUNT) : "",
+            route.constraints? ? "(#{format_constraints(route)})".ljust(EXTRA_LARGE_STRING_JUSTIFY_AMOUNT) : ""
+          ].join
+        end
+
+        def format_constraints(route)
+          route.inspect_constraints(route.constraints)
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/router/inspector.rb
+++ b/lib/hanami/router/inspector.rb
@@ -1,16 +1,24 @@
 # frozen_string_literal: true
 
+require "hanami/router/formatter/human_friendly"
+
 module Hanami
   class Router
     # Routes inspector
     #
-    # @api private
+    # Builds a representation of an array of routes according to a given
+    # formatter.
+    #
     # @since 2.0.0
     class Inspector
-      # @api private
+      # @param routes [Array<Hanami::Route>]
+      # @param formatter [#call] Takes the routes as an argument and returns
+      #   whatever representation it creates. Defaults to
+      #   {Hanami::Router::Formatter::HumanFriendly}.
       # @since 2.0.0
-      def initialize(routes: [])
+      def initialize(routes: [], formatter: Formatter::HumanFriendly.new)
         @routes = routes
+        @formatter = formatter
       end
 
       # @param route [Hash] serialized route
@@ -21,18 +29,12 @@ module Hanami
         @routes.push(route)
       end
 
-      # @return [String] The inspected routes
+      # @return [Any] Formatted routes
       #
-      # @api private
       # @since 2.0.0
       def call(*)
-        @routes.map(&:to_inspect).join(NEW_LINE)
+        @formatter.call(@routes)
       end
-
-      # @api private
-      # @since 2.0.0
-      NEW_LINE = $/
-      private_constant :NEW_LINE
     end
   end
 end

--- a/lib/hanami/router/route.rb
+++ b/lib/hanami/router/route.rb
@@ -5,24 +5,27 @@ require "hanami/router/block"
 
 module Hanami
   class Router
+    # A route from the router
+    #
+    # @since 2.0.0
     class Route
       # @api private
       # @since 2.0.0
+      ROUTE_CONSTRAINT_SEPARATOR = ", "
+      private_constant :ROUTE_CONSTRAINT_SEPARATOR
+
+      # @since 2.0.0
       attr_reader :http_method
 
-      # @api private
       # @since 2.0.0
       attr_reader :path
 
-      # @api private
       # @since 2.0.0
       attr_reader :to
 
-      # @api private
       # @since 2.0.0
       attr_reader :as
 
-      # @api private
       # @since 2.0.0
       attr_reader :constraints
 
@@ -38,68 +41,16 @@ module Hanami
         freeze
       end
 
-      # @api private
-      # @since 2.0.0
-      def to_inspect
-        return EMPTY_ROUTE if head?
-
-        result = http_method.to_s.ljust(SMALL_STRING_JUSTIFY_AMOUNT)
-        result += path.ljust(LARGE_STRING_JUSTIFY_AMOUNT)
-        result += inspect_to(to).ljust(LARGE_STRING_JUSTIFY_AMOUNT)
-        result += "as #{as.inspect}".ljust(MEDIUM_STRING_JUSTIFY_AMOUNT) if as
-
-        if constraints?
-          result += "(#{inspect_constraints(constraints)})".ljust(EXTRA_LARGE_STRING_JUSTIFY_AMOUNT)
-        end
-
-        result
-      end
-
-      private
-
-      # @api private
-      # @since 2.0.0
-      EMPTY_ROUTE = ""
-      private_constant :EMPTY_ROUTE
-
-      # @api private
-      # @since 2.0.0
-      ROUTE_CONSTRAINT_SEPARATOR = ", "
-      private_constant :ROUTE_CONSTRAINT_SEPARATOR
-
-      # @api private
-      # @since 2.0.0
-      SMALL_STRING_JUSTIFY_AMOUNT = 8
-      private_constant :SMALL_STRING_JUSTIFY_AMOUNT
-
-      # @api private
-      # @since 2.0.0
-      MEDIUM_STRING_JUSTIFY_AMOUNT = 20
-      private_constant :MEDIUM_STRING_JUSTIFY_AMOUNT
-
-      # @api private
-      # @since 2.0.0
-      LARGE_STRING_JUSTIFY_AMOUNT = 30
-      private_constant :LARGE_STRING_JUSTIFY_AMOUNT
-
-      # @api private
-      # @since 2.0.0
-      EXTRA_LARGE_STRING_JUSTIFY_AMOUNT = 40
-      private_constant :EXTRA_LARGE_STRING_JUSTIFY_AMOUNT
-
-      # @api private
       # @since 2.0.0
       def head?
         http_method == "HEAD"
       end
 
-      # @api private
       # @since 2.0.0
       def constraints?
         constraints.any?
       end
 
-      # @api private
       # @since 2.0.0
       def inspect_to(to)
         case to
@@ -118,7 +69,6 @@ module Hanami
         end
       end
 
-      # @api private
       # @since 2.0.0
       def inspect_constraints(constraints)
         constraints.map do |key, value|

--- a/spec/unit/hanami/router/formatter/human_friendly_spec.rb
+++ b/spec/unit/hanami/router/formatter/human_friendly_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "hanami/router/formatter/human_friendly"
+
+RSpec.describe Hanami::Router::Formatter::HumanFriendly do
+  describe "#call" do
+    context "with no routes" do
+      it "returns an empty string" do
+        expect(subject.call([])).to eq("")
+      end
+    end
+
+    context "with routes" do
+      it "returns a human friendly representation of them" do
+        routes = [
+          Hanami::Router::Route.new(http_method: "GET", path: "/resources/:id", to: "resource#show", as: :resource, constraints: {id: /\d+/})
+        ]
+
+        expected = "GET     /resources/:id                resource#show                 as :resource        (id: /\\d+/)                             "
+        expect(subject.call(routes)).to eq(expected)
+      end
+
+      it "separates routes with line breaks" do
+        routes = [
+          Hanami::Router::Route.new(http_method: "GET", path: "/", to: "home#index", as: :root, constraints: {}),
+          Hanami::Router::Route.new(http_method: "GET", path: "/about", to: "home#about", as: :root, constraints: {})
+        ]
+
+        rendered_routes = subject.call(routes).split($/)
+
+        aggregate_failures do
+          expect(rendered_routes.count).to be(2)
+          expect(rendered_routes[0]).to include("home#index")
+          expect(rendered_routes[1]).to include("home#about")
+        end
+      end
+
+      it "doesn't include HEAD routes" do
+        routes = [
+          Hanami::Router::Route.new(http_method: "HEAD", path: "/resources/:id", to: "resource#show")
+        ]
+
+        expect(subject.call(routes)).not_to include("resource#show")
+      end
+
+      it "doesn't break when 'as' is not provided" do
+        routes = [
+          Hanami::Router::Route.new(http_method: "GET", path: "/resources/:id", to: "resource#show", constraints: {id: /\d+/})
+        ]
+
+        expect { subject.call(routes) }.not_to raise_error
+      end
+
+      it "doesn't break when 'constraints' is not provided" do
+        routes = [
+          Hanami::Router::Route.new(http_method: "GET", path: "/resources/:id", to: "resource#show", as: :resource)
+        ]
+
+        expect { subject.call(routes) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/router/inspector_spec.rb
+++ b/spec/unit/hanami/router/inspector_spec.rb
@@ -3,44 +3,37 @@
 require "hanami/router/inspector"
 
 RSpec.describe Hanami::Router::Inspector do
-  subject { described_class.new(routes: routes) }
-  let(:routes) { [] }
-
-  describe "#initialize" do
-    it "returns a frozen instance of #{described_class}" do
-      expect(subject).to be_kind_of(described_class)
-    end
-  end
-
   describe "#add_route" do
     it "adds a route to the inspector" do
-      subject.add_route(Hanami::Router::Route.new(http_method: "GET", path: "/", to: "home#index"))
-      expect(subject.call).to include("GET     /                             home#index")
+      inspector = described_class.new
+
+      inspector.add_route(Hanami::Router::Route.new(http_method: "GET", path: "/", to: "home#index"))
+
+      expect(inspector.call).to include("home#index")
     end
   end
 
   describe "#call" do
-    context "no routes" do
-      it "returns an empty result" do
-        expect(subject.call(routes)).to eq("")
-      end
+    it "forwards to the formatter with the given routes" do
+      routes = [
+        Hanami::Router::Route.new(http_method: "GET", path: "/", to: "home#index", as: :root, constraints: {}),
+        Hanami::Router::Route.new(http_method: "GET", path: "/about", to: "home#about", as: :about, constraints: {})
+      ]
+      formatter = ->(rs) { rs.map(&:path).join("+") }
+
+      inspector = described_class.new(routes: routes, formatter: formatter)
+
+      expect(inspector.call).to eq("/+/about")
     end
 
-    context "with routes" do
-      let(:routes) do
-        [Hanami::Router::Route.new(http_method: "GET", path: "/", to: "home#index", as: :root, constraints: {}, blk: nil)]
-      end
+    it "defaults to the human friendly formatter" do
+      routes = [
+        Hanami::Router::Route.new(http_method: "GET", path: "/", to: "home#index", as: :root, constraints: {})
+      ]
 
-      it "returns inspected routes" do
-        expected = [
-          "GET     /                             home#index                    as :root"
-        ]
+      inspector = described_class.new(routes: routes)
 
-        actual = subject.call
-        expected.each do |route|
-          expect(actual).to include(route)
-        end
-      end
+      expect(inspector.call).to eq(Hanami::Router::Formatter::HumanFriendly.new.call(routes))
     end
   end
 end


### PR DESCRIPTION
Up to this point, the route inspector always returned a visually
attractive representation of the routes. Now, that format has been
extracted to a `Hanami::Formatter::HumanFriendly` class, while others
are allowed to be injected.

That allows the creation of other algorithms that can be helpful for
purposes beyond a visual inspection, like CSV, JSON, or import formats
for API documentation and platforms.

As others can create their formatters, we're changing the visibility of
`Hanami::Inspector` and `Hanami::Route` methods to be public.

We've taken the occasion to refactor the extracted code, so it doesn't
mutate a variable. We've also removed the test on
`Hanami::Inspector#initialize` as it stated something obvious, and the
description was out of date since https://github.com/hanami/router/commit/9936225e36814fbed215d491479597c62b397b66 (no longer
frozen).

There's a second commit fixing a Rubocop offense to make CI green.