### PR TITLE
Add CSV formatter

### DIFF
--- a/lib/hanami/router/formatter/csv.rb
+++ b/lib/hanami/router/formatter/csv.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Hanami
+  class Router
+    # Renders a CSV representation of the routes
+    #
+    # You can forward [CSV generation
+    # options](https://ruby-doc.org/stdlib-3.1.0/libdoc/csv/rdoc/CSV.html#class-CSV-label-Options+for+Generating]
+    # when calling it:
+    #
+    # ```
+    # require "hanami/router/inspector"
+    # require "hanami/router/formatter/csv"
+    #
+    # Hanami::Router::Inspector.new(
+    #   routes: Router.routes,
+    #   formatter: Hanami::Router::Formatter::CSV.new
+    # ).call(write_headers: false)
+    # ```
+    #
+    # @api private
+    # @since 2.0.0
+    module Formatter
+      class CSV
+        # @api private
+        # @since 2.0.0
+        DEFAULT_OPTIONS = {
+          write_headers: true
+        }.freeze
+
+        # @api private
+        # @since 2.0.0
+        HEADERS = %w[METHOD PATH TO AS CONSTRAINTS].freeze
+
+        # @api private
+        # @since 2.0.0
+        def call(routes, **csv_opts)
+          ::CSV.generate(**DEFAULT_OPTIONS.merge(csv_opts)) do |csv|
+            csv << HEADERS if csv.write_headers?
+            routes.reduce(csv) do |acc, route|
+              route.head? ? acc : acc << row(route)
+            end
+          end
+        end
+
+        private
+
+        def row(route)
+          [
+            route.http_method.to_s,
+            route.path,
+            route.inspect_to(route.to),
+            route.as ? route.as.inspect : "",
+            route.constraints? ? format_constraints(route) : ""
+          ]
+        end
+
+        def format_constraints(route)
+          route.inspect_constraints(route.constraints)
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/router/inspector.rb
+++ b/lib/hanami/router/inspector.rb
@@ -32,8 +32,8 @@ module Hanami
       # @return [Any] Formatted routes
       #
       # @since 2.0.0
-      def call(*)
-        @formatter.call(@routes)
+      def call(...)
+        @formatter.call(@routes, ...)
       end
     end
   end

--- a/spec/unit/hanami/router/formatter/csv_spec.rb
+++ b/spec/unit/hanami/router/formatter/csv_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "hanami/router/formatter/csv"
+
+RSpec.describe Hanami::Router::Formatter::CSV do
+  let(:headers) { described_class::HEADERS.join(",") }
+
+  describe "#call" do
+    it "returns a CSV representation of the routes" do
+      routes = [
+        Hanami::Router::Route.new(http_method: "GET", path: "/resources/:id", to: "resource#show", as: :resource, constraints: {id: /\d+/})
+      ]
+
+      expected = "GET,/resources/:id,resource#show,:resource,id: /\\d+/"
+      expect(subject.call(routes)).to eq("#{headers}\n#{expected}\n")
+    end
+
+    it "includes the headers by default" do
+      expect(subject.call([])).to include(headers)
+    end
+
+    it "can provide generating options" do
+      routes = [
+        Hanami::Router::Route.new(http_method: "GET", path: "/", to: "home#index", as: :root, constraints: {})
+      ]
+
+      rendered_routes = subject.call(routes, col_sep: ";", write_headers: false)
+
+      expected = "GET;/;home#index;:root;\"\"\n"
+      expect(rendered_routes).to eq(expected)
+    end
+
+    it "doesn't include HEAD routes" do
+      routes = [
+        Hanami::Router::Route.new(http_method: "HEAD", path: "/resources/:id", to: "resource#show")
+      ]
+
+      expect(subject.call(routes)).not_to include("resource#show")
+    end
+
+    it "doesn't break when 'as' is not provided" do
+      routes = [
+        Hanami::Router::Route.new(http_method: "GET", path: "/resources/:id", to: "resource#show", constraints: {id: /\d+/})
+      ]
+
+      expect { subject.call(routes) }.not_to raise_error
+    end
+
+    it "doesn't break when 'constraints' is not provided" do
+      routes = [
+        Hanami::Router::Route.new(http_method: "GET", path: "/resources/:id", to: "resource#show", as: :resource)
+      ]
+
+      expect { subject.call(routes) }.not_to raise_error
+    end
+  end
+end

--- a/spec/unit/hanami/router/inspector_spec.rb
+++ b/spec/unit/hanami/router/inspector_spec.rb
@@ -26,6 +26,17 @@ RSpec.describe Hanami::Router::Inspector do
       expect(inspector.call).to eq("/+/about")
     end
 
+    it "forwards arguments to the formatter" do
+      routes = [
+        Hanami::Router::Route.new(http_method: "GET", path: "/", to: "home#index", as: :root, constraints: {}),
+        Hanami::Router::Route.new(http_method: "GET", path: "/about", to: "home#about", as: :about, constraints: {})
+      ]
+      formatter = ->(rs, join_with:) { rs.map(&:path).join(join_with) }
+      inspector = described_class.new(routes: routes, formatter: formatter)
+
+      expect(inspector.call(join_with: "-")).to eq("/-/about")
+    end
+
     it "defaults to the human friendly formatter" do
       routes = [
         Hanami::Router::Route.new(http_method: "GET", path: "/", to: "home#index", as: :root, constraints: {})


### PR DESCRIPTION
Adds a routes formatter that generates a CSV output.

We've changed the inspector to forward arguments to the underlying
formatter. In this particular case, it allows using [CSV generation
options](https://ruby-doc.org/stdlib-3.1.0/libdoc/csv/rdoc/CSV.html#class-CSV-label-Options+for+Generating).