### PR TITLE
Ensure to require `hanami/middleware/error` from `hanami/middleware/body_parser/errors`

### DIFF
--- a/lib/hanami/middleware/body_parser/errors.rb
+++ b/lib/hanami/middleware/body_parser/errors.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "hanami/middleware/error"
+
 module Hanami
   module Middleware
     # @since 1.3.0

--- a/lib/hanami/middleware/error.rb
+++ b/lib/hanami/middleware/error.rb
@@ -5,7 +5,7 @@ module Hanami
   #
   # @since 1.3.0
   module Middleware
-    unless defined?(Error)
+    unless defined?(::Hanami::Middleware::Error)
       # Base error for Rack middleware
       #
       # @since 2.0.0


### PR DESCRIPTION
From a Hanami app while trying to use `Hanami::Middleware::BodyParser`

```
An error occurred while loading spec_helper.
Failure/Error: require "hanami/prepare"

NameError:
  uninitialized constant Hanami::Middleware::Error

        class BodyParsingError < Hanami::Middleware::Error
                                                   ^^^^^^^
  Did you mean?  IOError
                 Errno
# /Users/jodosha/.gem/ruby/3.1.0/gems/hanami-router-2.0.0.beta1/lib/hanami/middleware/body_parser/errors.rb:12:in `<class:BodyParser>'
# ...
```