### PR TITLE
Support configurable body parsers

### DIFF
--- a/lib/hanami/middleware/body_parser.rb
+++ b/lib/hanami/middleware/body_parser.rb
@@ -56,15 +56,17 @@ module Hanami
 
       private
 
-      def build_parsers(parser_names)
-        parser_names = Array(parser_names)
-        return {} if parser_names.empty?
+      def build_parsers(parser_specs)
+        parsers = Array(parser_specs).flatten(0)
 
-        parser_names.each_with_object({}) do |name, parsers|
-          parser = self.class.for(name)
+        return {} if parsers.empty?
+
+        parsers.each_with_object({}) do |spec, memo|
+          name, *mime_types = Array(*spec).flatten(0)
+          parser = self.class.for(name, mime_types: mime_types)
 
           parser.mime_types.each do |mime|
-            parsers[mime] = parser
+            memo[mime] = parser
           end
         end
       end

--- a/lib/hanami/middleware/body_parser.rb
+++ b/lib/hanami/middleware/body_parser.rb
@@ -37,7 +37,7 @@ module Hanami
 
       def initialize(app, parsers)
         @app = app
-        @parsers = build_parsers(parsers)
+        @parsers = parsers
       end
 
       def call(env)
@@ -55,21 +55,6 @@ module Hanami
       end
 
       private
-
-      def build_parsers(parser_specs)
-        parsers = Array(parser_specs).flatten(0)
-
-        return {} if parsers.empty?
-
-        parsers.each_with_object({}) do |spec, memo|
-          name, *mime_types = Array(*spec).flatten(0)
-          parser = self.class.for(name, mime_types: mime_types)
-
-          parser.mime_types.each do |mime|
-            memo[mime] = parser
-          end
-        end
-      end
 
       # @api private
       def _symbolize(body)

--- a/lib/hanami/middleware/body_parser/class_interface.rb
+++ b/lib/hanami/middleware/body_parser/class_interface.rb
@@ -21,7 +21,7 @@ module Hanami
           parser =
             case parser
             when String, Symbol
-              build(require_parser(parser), **config)
+              build(parser_class(parser), **config)
             when Class
               parser.new(**config)
             else
@@ -64,18 +64,22 @@ module Hanami
 
         # @api private
         # @since 1.3.0
-        def require_parser(parser)
-          require "hanami/middleware/body_parser/#{parser}_parser"
+        def parser_class(parser_name)
+          require "hanami/middleware/body_parser/#{parser_name}_parser"
 
-          load_parser!("#{classify(parser)}Parser")
+          load_parser!("#{classify(parser_name)}Parser")
         rescue LoadError, NameError
-          raise UnknownParserError.new(parser)
+          raise UnknownParserError, parser_name
         end
 
+        # @api private
+        # @since 1.3.0
         def classify(parser)
           parser.to_s.split(/_/).map(&:capitalize).join
         end
 
+        # @api private
+        # @since 1.3.0
         def load_parser!(class_name)
           Hanami::Middleware::BodyParser.const_get(class_name, false)
         end

--- a/lib/hanami/middleware/body_parser/class_interface.rb
+++ b/lib/hanami/middleware/body_parser/class_interface.rb
@@ -59,7 +59,9 @@ module Hanami
         # @api private
         # @since 1.3.0
         def ensure_parser(parser)
-          raise InvalidParserError.new(parser) unless PARSER_METHODS.all? { |method| parser.respond_to?(method) }
+          unless PARSER_METHODS.all? { |method| parser.respond_to?(method) }
+            raise InvalidParserError.new(parser)
+          end
         end
 
         # @api private

--- a/lib/hanami/middleware/body_parser/class_interface.rb
+++ b/lib/hanami/middleware/body_parser/class_interface.rb
@@ -100,11 +100,11 @@ module Hanami
 
           begin
             require "hanami/middleware/body_parser/#{parser_name}_parser"
-          rescue LoadError;end
+          rescue LoadError; end
 
           begin
             parser = load_parser!("#{classify(parser_name)}Parser")
-          rescue NameError;end
+          rescue NameError; end
 
           parser
         ensure

--- a/lib/hanami/middleware/body_parser/class_interface.rb
+++ b/lib/hanami/middleware/body_parser/class_interface.rb
@@ -11,13 +11,13 @@ module Hanami
       module ClassInterface
         # @api private
         # @since 1.3.0
-        def for(parser)
+        def for(parser, **config)
           parser =
             case parser
             when String, Symbol
-              require_parser(parser)
+              self.for(require_parser(parser), **config)
             when Class
-              parser.new
+              parser.new(**config)
             else
               parser
             end
@@ -44,7 +44,7 @@ module Hanami
         def require_parser(parser)
           require "hanami/middleware/body_parser/#{parser}_parser"
 
-          load_parser!("#{classify(parser)}Parser").new
+          load_parser!("#{classify(parser)}Parser")
         rescue LoadError, NameError
           raise UnknownParserError.new(parser)
         end

--- a/lib/hanami/middleware/body_parser/class_interface.rb
+++ b/lib/hanami/middleware/body_parser/class_interface.rb
@@ -94,6 +94,7 @@ module Hanami
 
         # @api private
         # @since 1.3.0
+        # rubocop:disable Lint/SuppressedException
         def parser_class(parser_name)
           parser = nil
 
@@ -109,6 +110,7 @@ module Hanami
         ensure
           raise UnknownParserError, parser_name unless parser
         end
+        # rubocop:enable Lint/SuppressedException
 
         # @api private
         # @since 1.3.0

--- a/lib/hanami/middleware/body_parser/class_interface.rb
+++ b/lib/hanami/middleware/body_parser/class_interface.rb
@@ -36,9 +36,9 @@ module Hanami
         # @api private
         # @since 2.0.0
         def build_parsers(parser_specs)
-          parsers = Array(parser_specs).flatten(0)
+          return DEFAULT_BODY_PARSERS if parser_specs.empty?
 
-          return {} if parsers.empty?
+          parsers = Array(parser_specs).flatten(0)
 
           parsers.each_with_object({}) do |spec, memo|
             name, *mime_types = Array(*spec).flatten(0)
@@ -55,6 +55,10 @@ module Hanami
         # @api private
         # @since 1.3.0
         PARSER_METHODS = %i[mime_types parse].freeze
+
+        # @api private
+        # @since 2.0.0
+        DEFAULT_BODY_PARSERS = {}.freeze
 
         # @api private
         # @since 1.3.0

--- a/lib/hanami/middleware/body_parser/class_interface.rb
+++ b/lib/hanami/middleware/body_parser/class_interface.rb
@@ -42,7 +42,8 @@ module Hanami
 
           parsers.each_with_object({}) do |spec, memo|
             name, *mime_types = Array(*spec).flatten(0)
-            parser = build(name, mime_types: mime_types)
+
+            parser = build(name, mime_types: mime_types.flatten)
 
             parser.mime_types.each do |mime|
               memo[mime] = parser

--- a/lib/hanami/middleware/body_parser/class_interface.rb
+++ b/lib/hanami/middleware/body_parser/class_interface.rb
@@ -9,8 +9,25 @@ module Hanami
       # @api private
       # @since 1.3.0
       module ClassInterface
+        # Instantiate a new body parser instance and load its parsers
+        #
+        # @example
+        #   Hanami::Middleware::BodyParser.new(->(env) { [200, {}, "app"] }, :json)
+        #
+        #   Hanami::Middleware::BodyParser.new(
+        #     ->(env) { [200, {}, "app"] }, [json: "application/json+scim"]
+        #   )
+        #
+        #   Hanami::Middleware::BodyParser.new(
+        #     ->(env) { [200, {}, "app"] }, [json: ["application/json+scim", "application/ld+json"]]
+        #   )
+        #
+        # @param app [#call]
+        # @param parser_specs [Symbol, Array<Hash>] parser name or name with mime-type(s)
+        #
         # @api private
         # @since 2.0.0
+        # @return BodyParser
         def new(app, parser_specs)
           super(app, build_parsers(parser_specs))
         end

--- a/lib/hanami/middleware/body_parser/json_parser.rb
+++ b/lib/hanami/middleware/body_parser/json_parser.rb
@@ -11,7 +11,7 @@ module Hanami
       class JsonParser < Parser
         # @since 1.3.0
         # @api private
-        def mime_types
+        def self.mime_types
           ["application/json", "application/vnd.api+json"]
         end
 

--- a/lib/hanami/middleware/body_parser/parser.rb
+++ b/lib/hanami/middleware/body_parser/parser.rb
@@ -18,7 +18,7 @@ module Hanami
         #   require "hanami/middleware/body_parser"
         #
         #   class XMLParser < Hanami::Middleware::BodyParser::Parser
-        #     def mime_types
+        #     def self.mime_types
         #       ["application/xml", "text/xml"]
         #     end
         #   end

--- a/lib/hanami/middleware/body_parser/parser.rb
+++ b/lib/hanami/middleware/body_parser/parser.rb
@@ -7,7 +7,7 @@ module Hanami
       #
       # @since 2.0.0
       class Parser
-        # Declare supported MIME types
+        # Return supported mime types
         #
         # @return [Array<String>] supported MIME types
         #
@@ -22,8 +22,11 @@ module Hanami
         #       ["application/xml", "text/xml"]
         #     end
         #   end
-        def mime_types
-          raise NotImplementedError
+        attr_reader :mime_types
+
+        # @api private
+        def initialize(mime_types: [])
+          @mime_types = self.class.mime_types + mime_types
         end
 
         # Parse raw HTTP request body

--- a/lib/hanami/middleware/body_parser/parser.rb
+++ b/lib/hanami/middleware/body_parser/parser.rb
@@ -7,6 +7,8 @@ module Hanami
       #
       # @since 2.0.0
       class Parser
+        DEFAULT_MIME_TYPES = [].freeze
+
         # Return supported mime types
         #
         # @return [Array<String>] supported MIME types
@@ -25,7 +27,7 @@ module Hanami
         attr_reader :mime_types
 
         # @api private
-        def initialize(mime_types: [])
+        def initialize(mime_types: DEFAULT_MIME_TYPES)
           @mime_types = self.class.mime_types + mime_types
         end
 

--- a/spec/integration/hanami/middleware/body_parser_spec.rb
+++ b/spec/integration/hanami/middleware/body_parser_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Hanami::Middleware::BodyParser do
   let(:app) { ->(_env) { [200, {}, "app"] } }
 
   describe ".new" do
-    it "accepts a parser identificator" do
+    it "accepts a parser name" do
       body_parser = Hanami::Middleware::BodyParser.new(app, :json)
 
       expect(body_parser.instance_variable_get("@parsers")["application/json"])
         .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)
     end
 
-    it "accepts a parser identificator with additional mime-type(s)" do
+    it "accepts a parser name with additional mime-type(s)" do
       body_parser = Hanami::Middleware::BodyParser.new(app, [json: "application/json+scim"])
 
       expect(body_parser.instance_variable_get("@parsers")["application/json+scim"])

--- a/spec/integration/hanami/middleware/body_parser_spec.rb
+++ b/spec/integration/hanami/middleware/body_parser_spec.rb
@@ -14,8 +14,17 @@ RSpec.describe Hanami::Middleware::BodyParser do
         .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)
     end
 
-    it "accepts a parser name with additional mime-type(s)" do
+    it "accepts a parser name with additional mime-type" do
       body_parser = Hanami::Middleware::BodyParser.new(app, [json: "application/json+scim"])
+
+      expect(body_parser.instance_variable_get("@parsers")["application/json+scim"])
+        .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)
+    end
+
+    it "accepts a parser name with additional mime-types" do
+      body_parser = Hanami::Middleware::BodyParser.new(
+        app, [json: ["application/json+scim", "application/json+foo"]]
+      )
 
       expect(body_parser.instance_variable_get("@parsers")["application/json+scim"])
         .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)

--- a/spec/integration/hanami/middleware/body_parser_spec.rb
+++ b/spec/integration/hanami/middleware/body_parser_spec.rb
@@ -52,6 +52,26 @@ RSpec.describe Hanami::Middleware::BodyParser do
       Hanami::Middleware::BodyParser.__send__(:remove_const, :XmlParser)
     end
 
+    it "accepts multiple parser class ids" do
+      class Hanami::Middleware::BodyParser::XmlParser < Hanami::Middleware::BodyParser::Parser
+        def self.mime_types
+          ["application/xml"]
+        end
+      end
+
+      body_parser = Hanami::Middleware::BodyParser.new(app, [:json, :xml])
+
+      parsers = body_parser.instance_variable_get("@parsers")
+
+      expect(parsers["application/json"])
+        .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)
+
+      expect(parsers["application/xml"])
+        .to be_instance_of(Hanami::Middleware::BodyParser::XmlParser)
+
+      Hanami::Middleware::BodyParser.__send__(:remove_const, :XmlParser)
+    end
+
     it "raises error when parser spec is invalid" do
       Hanami::Middleware::BodyParser.new(app, :a_parser)
     rescue Hanami::Middleware::BodyParser::UnknownParserError => exception

--- a/spec/integration/hanami/middleware/body_parser_spec.rb
+++ b/spec/integration/hanami/middleware/body_parser_spec.rb
@@ -30,6 +30,28 @@ RSpec.describe Hanami::Middleware::BodyParser do
         .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)
     end
 
+    it "accepts multiple parser names with additional mime-type" do
+      class Hanami::Middleware::BodyParser::XmlParser < Hanami::Middleware::BodyParser::Parser
+        def self.mime_types
+          ["application/xml"]
+        end
+      end
+
+      body_parser = Hanami::Middleware::BodyParser.new(
+        app, [{json: "application/json+scim", xml: ["application/xml"]}]
+      )
+
+      parsers = body_parser.instance_variable_get("@parsers")
+
+      expect(parsers["application/json+scim"])
+        .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)
+
+      expect(parsers["application/xml"])
+        .to be_instance_of(Hanami::Middleware::BodyParser::XmlParser)
+
+      Hanami::Middleware::BodyParser.__send__(:remove_const, :XmlParser)
+    end
+
     it "raises error when parser spec is invalid" do
       Hanami::Middleware::BodyParser.new(app, :a_parser)
     rescue Hanami::Middleware::BodyParser::UnknownParserError => exception

--- a/spec/integration/hanami/middleware/body_parser_spec.rb
+++ b/spec/integration/hanami/middleware/body_parser_spec.rb
@@ -6,8 +6,22 @@ require "rack/mock"
 RSpec.describe Hanami::Middleware::BodyParser do
   let(:app) { ->(_env) { [200, {}, "app"] } }
 
-  context "unknown parser" do
-    it "raises error" do
+  describe ".new" do
+    it "accepts a parser identificator" do
+      body_parser = Hanami::Middleware::BodyParser.new(app, :json)
+
+      expect(body_parser.instance_variable_get("@parsers")["application/json"])
+        .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)
+    end
+
+    it "accepts a parser identificator with additional mime-type(s)" do
+      body_parser = Hanami::Middleware::BodyParser.new(app, [json: "application/json+scim"])
+
+      expect(body_parser.instance_variable_get("@parsers")["application/json+scim"])
+        .to be_instance_of(Hanami::Middleware::BodyParser::JsonParser)
+    end
+
+    it "raises error when parser spec is invalid" do
       Hanami::Middleware::BodyParser.new(app, :a_parser)
     rescue Hanami::Middleware::BodyParser::UnknownParserError => exception
       expect(exception.message).to eq("Unknown body parser: `:a_parser'")

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -534,7 +534,7 @@ module Keys
 end # Keyboards
 
 class XMLBodyParser < Hanami::Middleware::BodyParser::Parser
-  def mime_types
+  def self.mime_types
     ["application/xml", "text/xml"]
   end
 

--- a/spec/unit/hanami/middleware/body_parser_spec.rb
+++ b/spec/unit/hanami/middleware/body_parser_spec.rb
@@ -4,7 +4,7 @@ require "hanami/middleware/body_parser"
 require "hanami/middleware/body_parser/json_parser"
 
 RSpec.describe Hanami::Middleware::BodyParser do
-  describe ".for" do
+  describe ".build" do
     let(:parser_class) do
       Class.new do
         def mime_types
@@ -18,26 +18,26 @@ RSpec.describe Hanami::Middleware::BodyParser do
     end
 
     it "requires and initializes a parser by name" do
-      expect(described_class.for(:json)).to be_a(Hanami::Middleware::BodyParser::JsonParser)
-      expect(described_class.for("json")).to be_a(Hanami::Middleware::BodyParser::JsonParser)
+      expect(described_class.build(:json)).to be_a(Hanami::Middleware::BodyParser::JsonParser)
+      expect(described_class.build("json")).to be_a(Hanami::Middleware::BodyParser::JsonParser)
     end
 
     it "raises an exception if a named parser cannot be found" do
-      expect { described_class.for(:unknown) }.to raise_exception(Hanami::Middleware::BodyParser::UnknownParserError)
+      expect { described_class.build(:unknown) }.to raise_exception(Hanami::Middleware::BodyParser::UnknownParserError)
     end
 
     it "initializes a parser from a class" do
-      expect(described_class.for(parser_class)).to be_a(parser_class)
+      expect(described_class.build(parser_class)).to be_a(parser_class)
     end
 
     it "passes through a parser instance" do
       parser = parser_class.new
-      expect(described_class.for(parser)).to eql parser
+      expect(described_class.build(parser)).to eql parser
     end
 
     it "raises an exception if the parser does not conform to requirements" do
       parser = Object.new
-      expect { described_class.for(parser) }.to raise_exception(Hanami::Middleware::BodyParser::InvalidParserError)
+      expect { described_class.build(parser) }.to raise_exception(Hanami::Middleware::BodyParser::InvalidParserError)
     end
   end
 end


### PR DESCRIPTION
- Allow passing mime types to the constructor of a Parser class
- Change `Parser#mime_types` to be `Parser.mime_types`
- Allow passing parser id along with additional mime types as an argument in the `BodyParser` constructor