### PR TITLE
Convert to Zeitwerk for code loading

### DIFF
--- a/hanami-router.gemspec
+++ b/hanami-router.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack",               "~> 2.0"
   spec.add_dependency "mustermann",         "~> 1.0"
   spec.add_dependency "mustermann-contrib", "~> 1.0"
+  spec.add_dependency "zeitwerk",           "~> 2.6"
 
   spec.add_development_dependency "bundler",   ">= 1.6", "< 3"
   spec.add_development_dependency "rake",      "~> 13"

--- a/lib/hanami-router.rb
+++ b/lib/hanami-router.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "hanami/router"

--- a/lib/hanami/middleware/body_parser.rb
+++ b/lib/hanami/middleware/body_parser.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "hanami/router/params"
-require "hanami/middleware/error"
+require "hanami/middleware/error" # from hanami-utils
 
 module Hanami
   module Middleware

--- a/lib/hanami/middleware/body_parser/errors.rb
+++ b/lib/hanami/middleware/body_parser/errors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "hanami/middleware/error"
+require "hanami/middleware/error" # from hanami-utils
 
 module Hanami
   module Middleware

--- a/lib/hanami/router/inspector.rb
+++ b/lib/hanami/router/inspector.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/router/formatter/human_friendly"
-
 module Hanami
   class Router
     # Builds a representation of an array of routes according to a given formatter.

--- a/lib/hanami/router/node.rb
+++ b/lib/hanami/router/node.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/router/segment"
-
 module Hanami
   class Router
     # Trie node

--- a/lib/hanami/router/route.rb
+++ b/lib/hanami/router/route.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/router/redirect"
-require "hanami/router/block"
-
 module Hanami
   class Router
     # A route from the router

--- a/lib/hanami/router/trie.rb
+++ b/lib/hanami/router/trie.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "hanami/router/node"
-
 module Hanami
   class Router
     # Trie data structure to store routes

--- a/lib/hanami/router/url_helpers.rb
+++ b/lib/hanami/router/url_helpers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "hanami/router/errors"
 require "mustermann/error"
+require_relative "errors"
 
 module Hanami
   class Router

--- a/lib/hanami/router/version.rb
+++ b/lib/hanami/router/version.rb
@@ -2,7 +2,7 @@
 
 module Hanami
   class Router
-    # Returns the hanami-router version.
+    # The current hanami-router version.
     #
     # @return [String]
     #


### PR DESCRIPTION
Covert the gem to use Zeitwerk for code loading. To do this:

- Add zeitwerk to the gemspec
- Add `lib/hanami-router.rb` so the gem follows a conventional structure
- Set up the Zeitwerk loader inside `lib/hanami/router.rb` (call it `.gem_loader` instead of `.loader` like we have done in other gems, since `Hanami::Router` is a class with other responsibilities, and `loader` is too generic a term)
- Remove all now-unneeded manual requires for files inside the gem

This is not a breaking change because any existing `require "hanami/router"` will continue to work as expected, since that is where the Zeitwerk loader setup is done.