### PR TITLE
Fix parsing of multipart/form-data

### DIFF
--- a/spec/integration/hanami/router/params_spec.rb
+++ b/spec/integration/hanami/router/params_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json"
+
 RSpec.describe "Params" do
   subject do
     e = endpoint
@@ -40,7 +42,7 @@ RSpec.describe "Params" do
 
   context "form payload" do
     it "has params from POST form submission" do
-      input = {"preferences" => {"language" => "Ruby", "framework" => "Hanami"}}
+      input = {"preferences" => {"language" => "Ruby", "framework" => "Hanami", "popularity" => "100%"}}
       env = Rack::MockRequest.env_for("/submit", method: "POST", params: input)
       subject.call(env)
 
@@ -64,6 +66,21 @@ RSpec.describe "Params" do
       expected = Rack::Utils.build_nested_query(input)
       expect(env["rack.input"].read).to eq(expected)
     end
+  end
+
+  context "json payload" do
+    it "shouldn't parse a json payload" do
+      input = JSON.generate("foo" => "100% bar")
+      env = Rack::MockRequest.env_for("/submit", method: "POST", params: input)
+      env["CONTENT_TYPE"] = "application/json"
+      subject.call(env)
+      
+      expect(env["router.params"]).to eq({})
+    end
+  end
+
+  context "file upload" do
+    # TODO: test a file upload
   end
 
   context "priority" do


### PR DESCRIPTION
I tried to fix issue #237. This also fixes the issue, posted at [hanami-discourse](https://discourse.hanamirb.org/t/when-i-upload-a-xml-file-i-get-rack-invalidparametererror/719).

I also tried to test a file upload. So far unfortunately without success. It fails with an `EOFError`. Do build the `multipart_fixture` I used some code from `rack`-specs.

WDYT?

Here's my approach:
```ruby
  context "file upload" do
    def multipart_fixture(name, boundary = "AaB03x")
      file = fixture_path(name)
      data = File.open(file, 'rb') { |io| io.read }
  
      type = %(multipart/form-data; boundary=#{boundary})
      length = data.size
  
      { "CONTENT_TYPE" => type,
        "CONTENT_LENGTH" => length.to_s,
        :input => StringIO.new(data) }
    end

    fit "should handle a file upload" do
      env = Rack::MockRequest.env_for(
        "/submit",
        multipart_fixture("foo.xml").merge(method: "POST"),
      )

      subject.call(env)

      puts env["router.params"]
    end
  end
```