### PR TITLE
Return HTTP response header `Allow` when returning `405` HTTP status

### DIFF
--- a/spec/integration/hanami/router/routing_spec.rb
+++ b/spec/integration/hanami/router/routing_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Hanami::Router do
 
         context "#HEAD" do
           let(:app) { Rack::MockRequest.new(Rack::Head.new(router)) }
-          let(:response) { Rack::MockResponse.new(405, {"Content-Length" => "18"}, []) }
+          let(:response) { Rack::MockResponse.new(405, {"Content-Length" => "18", "Allow" => verb.upcase}, []) }
 
           context "path recognition" do
             context "fixed string" do

--- a/spec/unit/hanami/router/not_allowed_spec.rb
+++ b/spec/unit/hanami/router/not_allowed_spec.rb
@@ -3,18 +3,83 @@
 RSpec.describe Hanami::Router do
   subject do
     described_class.new do
-      get "/", to: ->(*) { [200, {"Content-Length" => "4"}, ["root"]] }
+      get "/", to: ->(*) {}
+      post "/books", to: ->(*) {}
+      put   "/login", to: ->(*) {}
+      patch "/login", to: ->(*) {}
+
+      get "/books/:id", to: ->(*) {}
+      post "/books/:id/comments", to: ->(*) {}
+      put   "/books/:book_id/comments/:id", to: ->(*) {}
+      patch "/books/:book_id/comments/:id", to: ->(*) {}
     end
   end
 
   describe "Not Allowed" do
-    it "it returns 405 when an endpoint can be found but the request uses the wrong HTTP verb" do
-      env = Rack::MockRequest.env_for("/", method: :post)
-      status, headers, body = subject.call(env)
+    context "fixed path" do
+      it "it returns 405" do
+        env = Rack::MockRequest.env_for("/", method: :post)
+        status, headers, body = subject.call(env)
 
-      expect(status).to  eq(405)
-      expect(headers).to eq("Content-Length" => "18")
-      expect(body).to    eq(["Method Not Allowed"])
+        expect(status).to  eq(405)
+        expect(headers).to eq("Content-Length" => "18", "Allow" => "GET, HEAD")
+        expect(body).to    eq(["Method Not Allowed"])
+      end
+
+      context "with single HTTP verb" do
+        it "it returns 405" do
+          env = Rack::MockRequest.env_for("/books", method: :options)
+          status, headers, body = subject.call(env)
+
+          expect(status).to  eq(405)
+          expect(headers).to eq("Content-Length" => "18", "Allow" => "POST")
+          expect(body).to    eq(["Method Not Allowed"])
+        end
+      end
+
+      context "with multiple HTTP verbs" do
+        it "it returns 405" do
+          env = Rack::MockRequest.env_for("/login", method: :delete)
+          status, headers, body = subject.call(env)
+
+          expect(status).to  eq(405)
+          expect(headers).to eq("Content-Length" => "18", "Allow" => "PUT, PATCH")
+          expect(body).to    eq(["Method Not Allowed"])
+        end
+      end
+    end
+
+    context "variable path" do
+      it "it returns 405" do
+        env = Rack::MockRequest.env_for("/books/23", method: :post)
+        status, headers, body = subject.call(env)
+
+        expect(status).to  eq(405)
+        expect(headers).to eq("Content-Length" => "18", "Allow" => "GET, HEAD")
+        expect(body).to    eq(["Method Not Allowed"])
+      end
+
+      context "with single HTTP verb" do
+        it "it returns 405" do
+          env = Rack::MockRequest.env_for("/books/23/comments", method: :options)
+          status, headers, body = subject.call(env)
+
+          expect(status).to  eq(405)
+          expect(headers).to eq("Content-Length" => "18", "Allow" => "POST")
+          expect(body).to    eq(["Method Not Allowed"])
+        end
+      end
+
+      context "with multiple HTTP verbs" do
+        it "it returns 405" do
+          env = Rack::MockRequest.env_for("/books/23/comments/99", method: :delete)
+          status, headers, body = subject.call(env)
+
+          expect(status).to  eq(405)
+          expect(headers).to eq("Content-Length" => "18", "Allow" => "PUT, PATCH")
+          expect(body).to    eq(["Method Not Allowed"])
+        end
+      end
     end
 
     it "doesn't cache previous 405 header responses" do


### PR DESCRIPTION
Fixes https://github.com/hanami/router/issues/227