### PR TITLE
Depend on `mustermann` and `mustermann-contrib` 3

### DIFF
--- a/hanami-router.gemspec
+++ b/hanami-router.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0"
 
   spec.add_dependency "rack",               "~> 2.0"
-  spec.add_dependency "mustermann",         "~> 1.0"
-  spec.add_dependency "mustermann-contrib", "~> 1.0"
+  spec.add_dependency "mustermann",         "~> 3.0"
+  spec.add_dependency "mustermann-contrib", "~> 3.0"
 
   spec.add_development_dependency "bundler",   ">= 1.6", "< 3"
   spec.add_development_dependency "rake",      "~> 13"


### PR DESCRIPTION
Keep up with latest dependencies.

This is a blocker for Ruby 3.2 compat.