### PR TITLE
Fix find dynamic path segment for midlewares

### DIFF
--- a/lib/hanami/middleware/node.rb
+++ b/lib/hanami/middleware/node.rb
@@ -37,8 +37,11 @@ module Hanami
         result = @children[segment]
         return result if result
 
-        dynamic_segment = @children.keys.find { |saved_segment| saved_segment.start_with?(":") }
-        @children.fetch(dynamic_segment) { self if leaf? }
+        @children.fetch(find_dynamic_segment) { self if leaf? }
+      end
+
+      def find_dynamic_segment
+        @children.keys.find { |saved_segment| saved_segment.start_with?(":") }
       end
 
       # @api private

--- a/lib/hanami/middleware/node.rb
+++ b/lib/hanami/middleware/node.rb
@@ -34,7 +34,11 @@ module Hanami
       # @api private
       # @since 2.0.0
       def get(segment)
-        @children.fetch(segment) { self if leaf? }
+        result = @children[segment]
+        return result if result
+
+        dynamic_segment = @children.keys.find { |saved_segment| saved_segment.start_with?(":") }
+        @children.fetch(dynamic_segment) { self if leaf? }
       end
 
       # @api private

--- a/spec/unit/hanami/middleware/node_spec.rb
+++ b/spec/unit/hanami/middleware/node_spec.rb
@@ -27,11 +27,23 @@ RSpec.describe Hanami::Middleware::Node do
 
   describe "#get" do
     context "when segment is found" do
-      it "returns the node" do
-        segment = "foo"
-        subject.put(segment)
+      context "and segment is defined as symbol" do
+        it "returns the node" do
+          segment = "foo"
+          dynamic_segment = ":bar"
+          subject.put(dynamic_segment)
 
-        expect(subject.get(segment)).to be_kind_of(described_class)
+          expect(subject.get(segment)).to be_kind_of(described_class)
+        end
+      end
+
+      context "and segment is defined as string" do
+        it "returns the node" do
+          segment = "foo"
+          subject.put(segment)
+
+          expect(subject.get(segment)).to be_kind_of(described_class)
+        end
       end
     end
 

--- a/spec/unit/hanami/middleware/node_spec.rb
+++ b/spec/unit/hanami/middleware/node_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe Hanami::Middleware::Node do
     end
   end
 
+  describe "#find_dynamic_segment" do
+    it "returns the dynamic segment value" do
+      dynamic_segment = ":bar"
+      subject.put(dynamic_segment)
+
+      expect(subject.find_dynamic_segment).to eq(":bar")
+    end
+  end
+
   describe "#app!" do
     it "sets the app" do
       subject.app!(double("app"))


### PR DESCRIPTION
Issue reported here: https://github.com/hanami/api/issues/29

Explanation:
path segments are saved as String, even dynamic segments started with ":"