### PR TITLE
UrlHelpers uses a consistent type for base_url

### DIFF
--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -147,7 +147,7 @@ module Hanami
     #   end
     #
     #   router.path(:root) # => "/"
-    #   router.url(:root)  # => "https://hanamirb.org"
+    #   router.url(:root)  # => #<URI::HTTPS https://hanamirb.org>
     def root(to: nil, &blk)
       get(ROOT_PATH, to: to, as: :root, &blk)
     end
@@ -191,7 +191,7 @@ module Hanami
     #   end
     #
     #   router.path(:welcome) # => "/"
-    #   router.url(:welcome)  # => "http://localhost/"
+    #   router.url(:welcome)  # => #<URI::HTTP http://localhost/>
     #
     # @example Constraints
     #   require "hanami/router"
@@ -466,7 +466,7 @@ module Hanami
     #
     # @param name [Symbol] the route name
     #
-    # @return [String]
+    # @return [URI::HTTP, URI::HTTPS]
     #
     # @raise [Hanami::Router::MissingRouteError] when the router fails to
     #   recognize a route, because of the given arguments.
@@ -483,9 +483,9 @@ module Hanami
     #     get "/:name", to: ->(*) { ... }, as: :framework
     #   end
     #
-    #   router.url(:login)                          # => "https://hanamirb.org/login"
-    #   router.url(:login, return_to: "/dashboard") # => "https://hanamirb.org/login?return_to=%2Fdashboard"
-    #   router.url(:framework, name: "router")      # => "https://hanamirb.org/router"
+    #   router.url(:login)                          # => #<URI::HTTPS https://hanamirb.org/login>
+    #   router.url(:login, return_to: "/dashboard") # => #<URI::HTTPS https://hanamirb.org/login?return_to=%2Fdashboard>
+    #   router.url(:framework, name: "router")      # => #<URI::HTTPS https://hanamirb.org/router>
     def url(name, variables = {})
       url_helpers.url(name, variables)
     end

--- a/lib/hanami/router/url_helpers.rb
+++ b/lib/hanami/router/url_helpers.rb
@@ -2,6 +2,7 @@
 
 require "hanami/router/errors"
 require "mustermann/error"
+require_relative "./prefix"
 
 module Hanami
   class Router
@@ -11,8 +12,11 @@ module Hanami
       # @since 2.0.0
       # @api private
       def initialize(base_url)
-        @base_url = base_url
+        @base_url = URI(base_url)
         @named = {}
+        prefix = @base_url.path
+        prefix = DEFAULT_PREFIX if prefix.empty?
+        @prefix = Prefix.new(prefix)
       end
 
       # @since 2.0.0
@@ -34,7 +38,7 @@ module Hanami
       # @since 2.0.0
       # @api private
       def url(name, variables = {})
-        @base_url + path(name, variables)
+        @base_url + @prefix.join(path(name, variables)).to_s
       end
     end
   end

--- a/spec/integration/hanami/router/prefix_option_spec.rb
+++ b/spec/integration/hanami/router/prefix_option_spec.rb
@@ -50,17 +50,17 @@ RSpec.describe Hanami::Router do
     end
 
     it "generates absolute URLs with prefix" do
-      expect(subject.url(:root)).to eq("https://hanami.test/admin")
+      expect(subject.url(:root)).to eq(URI("https://hanami.test/admin"))
 
-      expect(subject.url(:get_home)).to eq("https://hanami.test/admin/home")
-      expect(subject.url(:post_home)).to eq("https://hanami.test/admin/home")
-      expect(subject.url(:put_home)).to eq("https://hanami.test/admin/home")
-      expect(subject.url(:patch_home)).to eq("https://hanami.test/admin/home")
-      expect(subject.url(:delete_home)).to eq("https://hanami.test/admin/home")
-      expect(subject.url(:trace_home)).to eq("https://hanami.test/admin/home")
-      expect(subject.url(:options_home)).to eq("https://hanami.test/admin/home")
+      expect(subject.url(:get_home)).to eq(URI("https://hanami.test/admin/home"))
+      expect(subject.url(:post_home)).to eq(URI("https://hanami.test/admin/home"))
+      expect(subject.url(:put_home)).to eq(URI("https://hanami.test/admin/home"))
+      expect(subject.url(:patch_home)).to eq(URI("https://hanami.test/admin/home"))
+      expect(subject.url(:delete_home)).to eq(URI("https://hanami.test/admin/home"))
+      expect(subject.url(:trace_home)).to eq(URI("https://hanami.test/admin/home"))
+      expect(subject.url(:options_home)).to eq(URI("https://hanami.test/admin/home"))
 
-      expect(subject.url(:dashboard_home)).to eq("https://hanami.test/admin/dashboard/home")
+      expect(subject.url(:dashboard_home)).to eq(URI("https://hanami.test/admin/dashboard/home"))
     end
 
     it "recognizes requests to root" do

--- a/spec/integration/hanami/router/routing_spec.rb
+++ b/spec/integration/hanami/router/routing_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Hanami::Router do
 
             it "recognizes by the given symbol" do
               expect(router.path(:"#{verb}_named_route")).to eq("/named_route")
-              expect(router.url(:"#{verb}_named_route")).to  eq("http://localhost/named_route")
+              expect(router.url(:"#{verb}_named_route")).to  eq(URI("http://localhost/named_route"))
             end
           end
 
@@ -107,7 +107,7 @@ RSpec.describe Hanami::Router do
 
             it "recognizes" do
               expect(router.path(:"#{verb}_named_route_var", var: "route")).to eq("/named_route")
-              expect(router.url(:"#{verb}_named_route_var", var: "route")).to  eq("http://localhost/named_route")
+              expect(router.url(:"#{verb}_named_route_var", var: "route")).to  eq(URI("http://localhost/named_route"))
             end
           end
 
@@ -120,7 +120,7 @@ RSpec.describe Hanami::Router do
                 __send__ verb, "/custom_named_route", to: ->(_) { r }, as: :"#{verb}_custom_named_route"
               end
 
-              expect(router.url(:"#{verb}_custom_named_route")).to eq("https://hanamirb.org/custom_named_route")
+              expect(router.url(:"#{verb}_custom_named_route")).to eq(URI("https://hanamirb.org/custom_named_route"))
             end
           end
         end
@@ -198,7 +198,7 @@ RSpec.describe Hanami::Router do
 
           it "recognizes by :root" do
             expect(router.path(:root)).to eq("/")
-            expect(router.url(:root)).to  eq("http://localhost/")
+            expect(router.url(:root)).to  eq(URI("http://localhost/"))
           end
         end
 

--- a/spec/support/generation_test_case.rb
+++ b/spec/support/generation_test_case.rb
@@ -67,6 +67,6 @@ class GenerationTestCase
   end
 
   def _absolute(expected)
-    "http://localhost#{expected}"
+    URI("http://localhost#{expected}")
   end
 end

--- a/spec/unit/hanami/router/new_spec.rb
+++ b/spec/unit/hanami/router/new_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Hanami::Router do
         root to: ->(*) {}
       end
 
-      expect(router.url(:root)).to match("https")
+      expect(router.url(:root)).to eq(URI("https://hanami.test"))
     end
 
     # FIXME: verify if Hanami::Router#defined? is still needed

--- a/spec/unit/hanami/router/url_spec.rb
+++ b/spec/unit/hanami/router/url_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe Hanami::Router do
 
   describe "#url" do
     it "recognizes fixed string" do
-      expect(router.url(:fixed)).to eq("#{base_url}/hanami")
+      expect(router.url(:fixed)).to eq(URI("#{base_url}/hanami"))
     end
 
     it "recognizes string with variables" do
-      expect(router.url(:variables, id: "hanami")).to eq("#{base_url}/flowers/hanami")
+      expect(router.url(:variables, id: "hanami")).to eq(URI("#{base_url}/flowers/hanami"))
     end
 
     it "raises error when variables aren't satisfied" do
@@ -29,27 +29,35 @@ RSpec.describe Hanami::Router do
     end
 
     it "recognizes string with variables and constraints" do
-      expect(router.url(:constraints, id: 23)).to eq("#{base_url}/books/23")
+      expect(router.url(:constraints, id: 23)).to eq(URI("#{base_url}/books/23"))
     end
 
     it "recognizes optional variables" do
-      expect(router.url(:optional)).to eq("#{base_url}/articles")
-      expect(router.url(:optional, page: "1")).to eq("#{base_url}/articles?page=1")
-      expect(router.url(:optional, format: "rss")).to eq("#{base_url}/articles.rss")
-      expect(router.url(:optional, format: "rss", page: "1")).to eq("#{base_url}/articles.rss?page=1")
+      expect(router.url(:optional)).to eq(URI("#{base_url}/articles"))
+      expect(router.url(:optional, page: "1")).to eq(URI("#{base_url}/articles?page=1"))
+      expect(router.url(:optional, format: "rss")).to eq(URI("#{base_url}/articles.rss"))
+      expect(router.url(:optional, format: "rss", page: "1")).to eq(URI("#{base_url}/articles.rss?page=1"))
     end
 
     it "recognizes glob string" do
-      expect(router.url(:glob)).to eq("#{base_url}/files/")
+      expect(router.url(:glob)).to eq(URI("#{base_url}/files/"))
     end
 
     it "escapes additional params in query string" do
-      expect(router.url(:fixed, return_to: "/dashboard")).to eq("#{base_url}/hanami?return_to=%2Fdashboard")
+      expect(router.url(:fixed, return_to: "/dashboard")).to eq(URI("#{base_url}/hanami?return_to=%2Fdashboard"))
     end
 
     # FIXME: should preserve this behavior?
     xit "raises error when insufficient params are passed" do
       expect { router.url(nil) }.to raise_error(Hanami::Router::InvalidRouteExpansionError, "No route could be generated for nil - please check given arguments")
+    end
+
+    context "base_url that contains a path" do
+      let(:base_url) { "https://hanami.test/example" }
+
+      it "doesn't clobber the base_url prefix" do
+        expect(router.url(:fixed)).to eq(URI("https://hanami.test/example/hanami"))
+      end
     end
   end
 end


### PR DESCRIPTION
There are subtle differences in behavior depending on whether it is a String or a URI. This patch forces it to be a URI and uses Prefix to construct absolute URLs.

I believe using strings for this was a mistake. The [public documentation](https://guides.hanamirb.org/v2.0/routing/overview/#named-routes) shows this as returning a URI object. This caused some spec churn, but I believe it is worth it for type consistency.

I propose using `Prefix` for this because it was built to do exactly what is needed here, and a path prefix on `base_url` is a very similar use-case to slice prefixes.

Fixes #249