### PR TITLE
Remove `frozen_string_literal: true` comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 gemspec
 

--- a/README.md
+++ b/README.md
@@ -250,8 +250,6 @@ It comes with a built-in JSON parser and allows to pass custom parsers.
 #### JSON Parsing
 
 ```ruby
-# frozen_string_literal: true
-
 require "hanami/router"
 require "hanami/middleware/body_parser"
 
@@ -286,8 +284,6 @@ If you want to use a different JSON backend, include `multi_json` in your `Gemfi
 #### Custom Parsers
 
 ```ruby
-# frozen_string_literal: true
-
 require "hanami/router"
 require "hanami/middleware/body_parser"
 
@@ -326,8 +322,6 @@ curl http://localhost:2300/authors/1 \
 ## Testing
 
 ```ruby
-# frozen_string_literal: true
-
 require "hanami/router"
 
 router = Hanami::Router.new do

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rake"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"

--- a/hanami-router.gemspec
+++ b/hanami-router.gemspec
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "hanami/router/version"

--- a/lib/hanami/middleware/app.rb
+++ b/lib/hanami/middleware/app.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/builder"
 require_relative "./trie"
 

--- a/lib/hanami/middleware/body_parser.rb
+++ b/lib/hanami/middleware/body_parser.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/params"
 require "hanami/middleware/error"
 require_relative "../router/constants"

--- a/lib/hanami/middleware/body_parser/class_interface.rb
+++ b/lib/hanami/middleware/body_parser/class_interface.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "errors"
 
 module Hanami

--- a/lib/hanami/middleware/body_parser/errors.rb
+++ b/lib/hanami/middleware/body_parser/errors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/middleware/error"
 
 module Hanami

--- a/lib/hanami/middleware/body_parser/form_parser.rb
+++ b/lib/hanami/middleware/body_parser/form_parser.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "parser"
 require "rack/multipart"
 

--- a/lib/hanami/middleware/body_parser/json_parser.rb
+++ b/lib/hanami/middleware/body_parser/json_parser.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "json"
 require_relative "parser"
 

--- a/lib/hanami/middleware/body_parser/parser.rb
+++ b/lib/hanami/middleware/body_parser/parser.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   module Middleware
     class BodyParser

--- a/lib/hanami/middleware/error.rb
+++ b/lib/hanami/middleware/error.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   # Hanami Rack middleware
   #

--- a/lib/hanami/middleware/node.rb
+++ b/lib/hanami/middleware/node.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/segment"
 
 module Hanami

--- a/lib/hanami/middleware/trie.rb
+++ b/lib/hanami/middleware/trie.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "./node"
 
 module Hanami

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack"
 require "rack/utils"
 

--- a/lib/hanami/router/block.rb
+++ b/lib/hanami/router/block.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Router
     # Block endpoint

--- a/lib/hanami/router/constants.rb
+++ b/lib/hanami/router/constants.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Router
     # @api private

--- a/lib/hanami/router/errors.rb
+++ b/lib/hanami/router/errors.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Router
     # Base class for all Hanami::Router errors.

--- a/lib/hanami/router/formatter/csv.rb
+++ b/lib/hanami/router/formatter/csv.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "csv"
 
 module Hanami

--- a/lib/hanami/router/formatter/human_friendly.rb
+++ b/lib/hanami/router/formatter/human_friendly.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Router
     # Renders a human friendly representation of the routes

--- a/lib/hanami/router/inspector.rb
+++ b/lib/hanami/router/inspector.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/formatter/human_friendly"
 
 module Hanami

--- a/lib/hanami/router/node.rb
+++ b/lib/hanami/router/node.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/segment"
 
 module Hanami

--- a/lib/hanami/router/params.rb
+++ b/lib/hanami/router/params.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Router
     # Params utilities

--- a/lib/hanami/router/prefix.rb
+++ b/lib/hanami/router/prefix.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Router
     # URL Path prefix

--- a/lib/hanami/router/recognized_route.rb
+++ b/lib/hanami/router/recognized_route.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Router
     # Represents a result of router path recognition.

--- a/lib/hanami/router/redirect.rb
+++ b/lib/hanami/router/redirect.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Router
     # HTTP Redirect

--- a/lib/hanami/router/route.rb
+++ b/lib/hanami/router/route.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/redirect"
 require "hanami/router/block"
 

--- a/lib/hanami/router/segment.rb
+++ b/lib/hanami/router/segment.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "mustermann/rails"
 
 module Hanami

--- a/lib/hanami/router/trie.rb
+++ b/lib/hanami/router/trie.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/node"
 
 module Hanami

--- a/lib/hanami/router/url_helpers.rb
+++ b/lib/hanami/router/url_helpers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/errors"
 require "mustermann/error"
 require_relative "./prefix"

--- a/lib/hanami/router/version.rb
+++ b/lib/hanami/router/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Hanami
   class Router
     # Returns the hanami-router version.

--- a/spec/integration/hanami/middleware/body_parser/parser_spec.rb
+++ b/spec/integration/hanami/middleware/body_parser/parser_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/middleware/body_parser"
 require "rack/mock"
 

--- a/spec/integration/hanami/middleware/body_parser_spec.rb
+++ b/spec/integration/hanami/middleware/body_parser_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/middleware/body_parser"
 require "rack/mock"
 

--- a/spec/integration/hanami/router/block_spec.rb
+++ b/spec/integration/hanami/router/block_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/mock"
 
 RSpec.describe Hanami::Router do

--- a/spec/integration/hanami/router/body_parsing_middelware_spec.rb
+++ b/spec/integration/hanami/router/body_parsing_middelware_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/middleware/body_parser"
 
 RSpec.describe "Body parsing" do

--- a/spec/integration/hanami/router/client_error_spec.rb
+++ b/spec/integration/hanami/router/client_error_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   before do
     @router = Hanami::Router.new { get "/", to: ->(env) {} }

--- a/spec/integration/hanami/router/context_spec.rb
+++ b/spec/integration/hanami/router/context_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   describe "context option" do
     let(:app) { Rack::MockRequest.new(router) }

--- a/spec/integration/hanami/router/generation_spec.rb
+++ b/spec/integration/hanami/router/generation_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   describe "generation" do
     let(:runner) { GenerationTestCase.new(router) }

--- a/spec/integration/hanami/router/inspection_spec.rb
+++ b/spec/integration/hanami/router/inspection_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/inspector"
 
 RSpec.describe "Router: inspection" do

--- a/spec/integration/hanami/router/inspector_nested_resources_spec.rb
+++ b/spec/integration/hanami/router/inspector_nested_resources_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.xdescribe "Inspector nested resources" do
   before do
     @router = Hanami::Router.new(namespace: Nested::Controllers) do

--- a/spec/integration/hanami/router/mount_spec.rb
+++ b/spec/integration/hanami/router/mount_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/head"
 
 RSpec.describe Hanami::Router do

--- a/spec/integration/hanami/router/params_spec.rb
+++ b/spec/integration/hanami/router/params_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "json"
 require "pathname"
 require "rack/builder"

--- a/spec/integration/hanami/router/pass_on_response_spec.rb
+++ b/spec/integration/hanami/router/pass_on_response_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Pass on response" do
   let(:app) { Rack::MockRequest.new(routes) }
   let(:routes) do

--- a/spec/integration/hanami/router/prefix_option_spec.rb
+++ b/spec/integration/hanami/router/prefix_option_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   describe "with prefix option" do
     subject do

--- a/spec/integration/hanami/router/recognition_spec.rb
+++ b/spec/integration/hanami/router/recognition_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   describe "recognition" do
     let(:runner) { RecognitionTestCase.new(router) }

--- a/spec/integration/hanami/router/request_url_spec.rb
+++ b/spec/integration/hanami/router/request_url_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/test"
 
 RSpec.xdescribe "SCRIPT_NAME" do

--- a/spec/integration/hanami/router/routing_spec.rb
+++ b/spec/integration/hanami/router/routing_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/head"
 
 RSpec.describe Hanami::Router do

--- a/spec/integration/hanami/router/scope_spec.rb
+++ b/spec/integration/hanami/router/scope_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack/head"
 
 RSpec.describe Hanami::Router do

--- a/spec/integration/hanami/router/showexceptions_spec.rb
+++ b/spec/integration/hanami/router/showexceptions_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   describe "usage with Rack::ShowExceptions" do
     let(:app) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 $LOAD_PATH.unshift "lib"
 require "hanami/utils"
 require "hanami/devtools/unit"

--- a/spec/support/body.rb
+++ b/spec/support/body.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module RSpec
   module Support
     module Body

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rexml/document"
 require "hanami/middleware/body_parser"
 

--- a/spec/support/generation_test_case.rb
+++ b/spec/support/generation_test_case.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class GenerationTestCase
   include ::RSpec::Matchers
   def initialize(router)

--- a/spec/support/http.rb
+++ b/spec/support/http.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module RSpec
   module Support
     module HTTP

--- a/spec/support/recognition_test_case.rb
+++ b/spec/support/recognition_test_case.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class RecognitionTestCase
   include ::RSpec::Matchers
   HEADER_ENV     = "_env"

--- a/spec/support/response_matcher.rb
+++ b/spec/support/response_matcher.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rspec/expectations"
 
 RSpec::Matchers.define :eq_response do |expected|

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/unit/hanami/middleware/app_spec.rb
+++ b/spec/unit/hanami/middleware/app_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/middleware/app"
 require "rack/mock"
 

--- a/spec/unit/hanami/middleware/body_parser_spec.rb
+++ b/spec/unit/hanami/middleware/body_parser_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/middleware/body_parser"
 require "hanami/middleware/body_parser/json_parser"
 

--- a/spec/unit/hanami/middleware/error_spec.rb
+++ b/spec/unit/hanami/middleware/error_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Middleware::BodyParser do
   it "inherits from Hanami::Routing::Error" do
     expect(Hanami::Middleware::BodyParser::BodyParsingError.superclass).to eq(Hanami::Middleware::Error)

--- a/spec/unit/hanami/middleware/node_spec.rb
+++ b/spec/unit/hanami/middleware/node_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/middleware/node"
 
 RSpec.describe Hanami::Middleware::Node do

--- a/spec/unit/hanami/middleware/trie_spec.rb
+++ b/spec/unit/hanami/middleware/trie_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/middleware/trie"
 
 RSpec.describe Hanami::Middleware::Trie do

--- a/spec/unit/hanami/router/define_spec.rb
+++ b/spec/unit/hanami/router/define_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   describe ".define" do
     it "returns block as it is" do

--- a/spec/unit/hanami/router/formatter/csv_spec.rb
+++ b/spec/unit/hanami/router/formatter/csv_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/formatter/csv"
 
 RSpec.describe Hanami::Router::Formatter::CSV do

--- a/spec/unit/hanami/router/formatter/human_friendly_spec.rb
+++ b/spec/unit/hanami/router/formatter/human_friendly_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/formatter/human_friendly"
 
 RSpec.describe Hanami::Router::Formatter::HumanFriendly do

--- a/spec/unit/hanami/router/inspector_spec.rb
+++ b/spec/unit/hanami/router/inspector_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/inspector"
 
 RSpec.describe Hanami::Router::Inspector do

--- a/spec/unit/hanami/router/new_spec.rb
+++ b/spec/unit/hanami/router/new_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   describe "#initialize" do
     let(:app) { Rack::MockRequest.new(router) }

--- a/spec/unit/hanami/router/not_allowed_spec.rb
+++ b/spec/unit/hanami/router/not_allowed_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "json"
 
 RSpec.describe Hanami::Router do

--- a/spec/unit/hanami/router/not_found_spec.rb
+++ b/spec/unit/hanami/router/not_found_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   subject { described_class.new {} }
 

--- a/spec/unit/hanami/router/path_spec.rb
+++ b/spec/unit/hanami/router/path_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   let(:router) do
     e = endpoint

--- a/spec/unit/hanami/router/recognize_spec.rb
+++ b/spec/unit/hanami/router/recognize_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   describe "#recognize" do
     let(:router) do

--- a/spec/unit/hanami/router/redirect_spec.rb
+++ b/spec/unit/hanami/router/redirect_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   describe "#redirect" do
     it "recognizes string endpoint" do

--- a/spec/unit/hanami/router/route_spec.rb
+++ b/spec/unit/hanami/router/route_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router::Route do
   describe "#inspect_to" do
     context "when it's a String" do

--- a/spec/unit/hanami/router/routing_spec.rb
+++ b/spec/unit/hanami/router/routing_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "hanami/router/inspector"
 
 RSpec.describe Hanami::Router do

--- a/spec/unit/hanami/router/url_spec.rb
+++ b/spec/unit/hanami/router/url_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe Hanami::Router do
   let(:router) do
     e = endpoint

--- a/spec/unit/hanami/router/version_spec.rb
+++ b/spec/unit/hanami/router/version_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Hanami::Router::VERSION" do
   it "exposes version" do
     expect(Hanami::Router::VERSION).to eq("2.0.3")


### PR DESCRIPTION
Since we've moved to requiring Ruby >= 3.0 we no longer need to have the
`#frozen_string_literal: true` magic comment as strings are now frozen
by default.