### PR TITLE
fix PATH_INFO/SCRIPT_NAME for root mounts

### DIFF
--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -637,11 +637,13 @@ module Hanami
       @mounted.each do |prefix, app|
         next unless (match = prefix.peek_match(env[::Rack::PATH_INFO]))
 
-        # TODO: ensure compatibility with existing env[::Rack::SCRIPT_NAME]
-        # TODO: cleanup this code
-        env[::Rack::SCRIPT_NAME] = env[::Rack::SCRIPT_NAME].to_s + prefix.to_s
-        env[::Rack::PATH_INFO] = env[::Rack::PATH_INFO].sub(prefix.to_s, EMPTY_STRING)
-        env[::Rack::PATH_INFO] = DEFAULT_PREFIX if env[::Rack::PATH_INFO] == EMPTY_STRING
+        if prefix.to_s == "/"
+          env[::Rack::SCRIPT_NAME] = EMPTY_STRING
+        else
+          env[::Rack::SCRIPT_NAME] = env[::Rack::SCRIPT_NAME].to_s + prefix.to_s
+          env[::Rack::PATH_INFO] = env[::Rack::PATH_INFO].sub(prefix.to_s, EMPTY_STRING)
+          env[::Rack::PATH_INFO] = DEFAULT_PREFIX if env[::Rack::PATH_INFO] == EMPTY_STRING
+        end
 
         return [app, match.named_captures]
       end


### PR DESCRIPTION
If a mounted Rack app is at the root of the Hanami app, it should keep the leading slash in PATH_INFO, and the SCRIPT_INFO value should be blank. As per [the Rack spec on SCRIPT_INFO](https://github.com/rack/rack/blob/main/SPEC.rdoc):

> This may be an empty string, if the application corresponds to the
> “root” of the server.

The existing behaviour for apps mounted in sub-paths was fine - it's just the root path situation that wasn't being handled correctly. (As initially reported in #261)

I don't feel this is a particularly elegant fix (especially the spec changes), so please suggest changes (or, edit my commit!) if so desired.