### PR TITLE
group globs and mounts together

### DIFF
--- a/lib/hanami/router/globbed_path.rb
+++ b/lib/hanami/router/globbed_path.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Router
+    class GlobbedPath
+      def initialize(http_method, path, to)
+        @http_method = http_method
+        @path = path
+        @to = to
+      end
+
+      def endpoint_and_params(env)
+        return [] unless @http_method == env[::Rack::REQUEST_METHOD]
+
+        if (match = @path.match(env[::Rack::PATH_INFO]))
+          [@to, match.named_captures]
+        else
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/router/mounted_path.rb
+++ b/lib/hanami/router/mounted_path.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Router
+    class MountedPath
+      def initialize(prefix, app)
+        @prefix = prefix
+        @app = app
+      end
+
+      def endpoint_and_params(env)
+        return [] unless (match = @prefix.peek_match(env[::Rack::PATH_INFO]))
+
+        if @prefix.to_s == "/"
+          env[::Rack::SCRIPT_NAME] = EMPTY_STRING
+        else
+          env[::Rack::SCRIPT_NAME] = env[::Rack::SCRIPT_NAME].to_s + @prefix.to_s
+          env[::Rack::PATH_INFO] = env[::Rack::PATH_INFO].sub(@prefix.to_s, EMPTY_STRING)
+          env[::Rack::PATH_INFO] = DEFAULT_PREFIX if env[::Rack::PATH_INFO] == EMPTY_STRING
+        end
+
+        [@app, match.named_captures]
+      end
+    end
+  end
+end

--- a/spec/integration/hanami/router/mount_spec.rb
+++ b/spec/integration/hanami/router/mount_spec.rb
@@ -72,5 +72,22 @@ RSpec.describe Hanami::Router do
     it "falls back to glob" do
       expect(app.request("GET", "/foo", lint: true).status).to eq(200)
     end
+
+    context "with more-specific glob before root-level mount" do
+      let(:router) do
+        Hanami::Router.new do
+          get "/home/*any", to: ->(*) { [200, {"Content-Length" => "4"}, ["home"]] }
+
+          mount Api::App.new, at: "/"
+        end
+      end
+
+      it "respects the glob" do
+        response = app.request("GET", "/home/foo", lint: true)
+
+        expect(response.status).to eq(200)
+        expect(response.body).to eq("home")
+      end
+    end
   end
 end

--- a/spec/unit/hanami/router/globbed_path_spec.rb
+++ b/spec/unit/hanami/router/globbed_path_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Router::GlobbedPath do
+  let(:http_method) { "PUT" }
+  let(:path) { Mustermann.new("/api/*any", type: :rails, version: "5.0") }
+  let(:to) { double(:endpoint) }
+
+  subject { described_class.new(http_method, path, to) }
+
+  describe "#endpoint_and_params" do
+    let(:env) { {} }
+
+    it "returns an empty array if the method doesn't match" do
+      env.merge!(
+        Rack::PATH_INFO => "/api/orders",
+        Rack::REQUEST_METHOD => "GET"
+      )
+
+      expect(subject.endpoint_and_params(env)).to eq([])
+    end
+
+    it "returns an empty array if the pattern doesn't match" do
+      env.merge!(
+        Rack::PATH_INFO => "/orders",
+        Rack::REQUEST_METHOD => "PUT"
+      )
+
+      expect(subject.endpoint_and_params(env)).to eq([])
+    end
+
+    it "returns the endpoint and captures if both method and pattern match" do
+      env.merge!(
+        Rack::PATH_INFO => "/api/orders",
+        Rack::REQUEST_METHOD => "PUT"
+      )
+
+      expect(subject.endpoint_and_params(env)).to eq([to, {"any" => "orders"}])
+    end
+  end
+end

--- a/spec/unit/hanami/router/mounted_path_spec.rb
+++ b/spec/unit/hanami/router/mounted_path_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Hanami::Router::MountedPath do
         expect(env[Rack::PATH_INFO]).to eq("/orders")
       end
 
-      it "uses a slahs for the PATH_INFO if it would otherwise be empty" do
+      it "uses a slash for the PATH_INFO if it would otherwise be empty" do
         env.merge!(Rack::PATH_INFO => "/api")
 
         subject.endpoint_and_params(env)

--- a/spec/unit/hanami/router/mounted_path_spec.rb
+++ b/spec/unit/hanami/router/mounted_path_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Router::MountedPath do
+  let(:prefix) { Mustermann.new("/api", type: :rails, version: "5.0") }
+  let(:app) { double(:app) }
+
+  subject { described_class.new(prefix, app) }
+
+  describe "#endpoint_and_params" do
+    let(:env) { {} }
+
+    it "returns an empty array if the path doesn't match the prefix" do
+      env.merge!(Rack::PATH_INFO => "/checkout")
+
+      expect(subject.endpoint_and_params(env)).to eq([])
+    end
+
+    it "returns the app and named captures when the path matches" do
+      env.merge!(Rack::PATH_INFO => "/api/orders")
+
+      expect(subject.endpoint_and_params(env)).to eq([app, {}])
+    end
+
+    context "with a root prefix" do
+      let(:prefix) { Mustermann.new("/", type: :rails, version: "5.0") }
+
+      before :each do
+        env.merge!(Rack::PATH_INFO => "/orders")
+      end
+
+      it "keeps the leading slash in the PATH_INFO" do
+        subject.endpoint_and_params(env)
+
+        expect(env[Rack::PATH_INFO]).to eq("/orders")
+      end
+
+      it "sets SCRIPT_NAME to be an empty string" do
+        subject.endpoint_and_params(env)
+
+        expect(env[Rack::SCRIPT_NAME]).to eq("")
+      end
+    end
+
+    context "with a non-root prefix" do
+      before :each do
+        env.merge!(Rack::PATH_INFO => "/api/orders")
+      end
+
+      it "adds the prefix to the SCRIPT_NAME" do
+        subject.endpoint_and_params(env)
+
+        expect(env[Rack::SCRIPT_NAME]).to eq("/api")
+      end
+
+      it "removes the prefix from the PATH_INFO" do
+        subject.endpoint_and_params(env)
+
+        expect(env[Rack::PATH_INFO]).to eq("/orders")
+      end
+
+      it "uses a slahs for the PATH_INFO if it would otherwise be empty" do
+        env.merge!(Rack::PATH_INFO => "/api")
+
+        subject.endpoint_and_params(env)
+
+        expect(env[Rack::PATH_INFO]).to eq("/")
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the previous approach, globs would not be considered if a mounted app matched the route. On first glance this would be fair, but if that mounted app is at the root, and the glob is not, then even when the glob is listed first, it would be ignored (see #262).

But, a glob and a mount are not so different - they both have the potential to be far-reaching catch-all endpoints (though a glob is http_method-specific). So let’s handle them in the same collection, which helps keep their listed order in a routes file. This allows more-specific globs to be considered before a less-specific mount, provided they’re ordered that way in the routes.

This commit does not play so nicely with #263 - but the change there can be easily applied to MountedPath in this PR. Also, I realise there's potential for unit tests and documentation, but I would appreciate confirmation that this approach has merit first! :)