### PR TITLE
Pass through kwargs to middleware

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,5 @@ Style/RescueStandardError:
 Style/CommentedKeyword:
   Exclude:
     - "spec/**/*.rb"
+Style/RedundantParentheses:
+  Enabled: false

--- a/lib/hanami/middleware/app.rb
+++ b/lib/hanami/middleware/app.rb
@@ -21,8 +21,8 @@ module Hanami
         mapping.each do |path, stack|
           builder = Rack::Builder.new
 
-          stack.each do |middleware, args, blk|
-            builder.use(middleware, *args, &blk)
+          stack.each do |middleware, args, kwargs, blk|
+            builder.use(middleware, *args, **kwargs, &blk)
           end
 
           builder.run(router)

--- a/lib/hanami/router/errors.rb
+++ b/lib/hanami/router/errors.rb
@@ -78,7 +78,7 @@ module Hanami
       # @since 0.5.0
       # @api private
       def initialize(env)
-        super %(Cannot find routable endpoint for: #{env[::Rack::REQUEST_METHOD]} #{env[::Rack::PATH_INFO]})
+        super(%(Cannot find routable endpoint for: #{env[::Rack::REQUEST_METHOD]} #{env[::Rack::PATH_INFO]}))
       end
     end
   end

--- a/spec/unit/hanami/middleware/app_spec.rb
+++ b/spec/unit/hanami/middleware/app_spec.rb
@@ -7,19 +7,21 @@ RSpec.describe Hanami::Middleware::App do
   subject { described_class.new(app, mapping) }
 
   let(:app) { Hanami::Router.new { root { "OK" } } }
-  let(:mapping) { {"/" => [], "/admin" => [[authentication, [], {}, nil]]} }
+  let(:mapping) { {"/" => [], "/admin" => [[authentication, ["arg"], {kwarg: "kwarg"}, nil]]} }
   let(:authentication) do
     Class.new do
       def self.inspect
         "<Middleware::Auth>"
       end
 
-      def initialize(app)
+      def initialize(app, arg, kwarg:)
         @app = app
+        @arg = arg
+        @kwarg = kwarg
       end
 
       def call(env)
-        env["AUTH_USER_ID"] = user_id = "23"
+        env["AUTH_USER_ID"] = user_id = "23 #{@arg} #{@kwarg}"
         status, headers, body = @app.call(env)
         headers["X-Auth-User-ID"] = user_id
 
@@ -46,7 +48,7 @@ RSpec.describe Hanami::Middleware::App do
       env = Rack::MockRequest.env_for("/admin")
       _, headers, _ = subject.call(env)
 
-      expect(headers).to have_key("X-Auth-User-ID")
+      expect(headers["X-Auth-User-ID"]).to eq "23 arg kwarg"
     end
   end
 

--- a/spec/unit/hanami/middleware/app_spec.rb
+++ b/spec/unit/hanami/middleware/app_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hanami::Middleware::App do
   subject { described_class.new(app, mapping) }
 
   let(:app) { Hanami::Router.new { root { "OK" } } }
-  let(:mapping) { {"/" => [], "/admin" => [[authentication, [], nil]]} }
+  let(:mapping) { {"/" => [], "/admin" => [[authentication, [], {}, nil]]} }
   let(:authentication) do
     Class.new do
       def self.inspect


### PR DESCRIPTION
Most middleware expect the old-school approach of hash options, but some are now using keyword arguments instead (such as Rack::Timeout). So let's presume that any keyword arguments that aren't known by Hanami should be passed through.

There is the edge-case of both the middleware and Hanami expecting arguments with the same name - this does not address that. 😓

This PR is paired with a forthcoming one for hanami/hanami, as that's where the various parameters are captured.