### PR TITLE
Update syntax for latest Rubocop rules

### DIFF
--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -918,7 +918,7 @@ module Hanami
         inspector: @inspector
       }
 
-      self.class.new(**options.merge(new_options), &(blk || @blk))
+      self.class.new(**options.merge(new_options), &blk || @blk)
     end
 
     # @since 2.0.0

--- a/lib/hanami/router/errors.rb
+++ b/lib/hanami/router/errors.rb
@@ -78,7 +78,7 @@ module Hanami
       # @since 0.5.0
       # @api private
       def initialize(env)
-        super %(Cannot find routable endpoint for: #{env[::Rack::REQUEST_METHOD]} #{env[::Rack::PATH_INFO]})
+        super(%(Cannot find routable endpoint for: #{env[::Rack::REQUEST_METHOD]} #{env[::Rack::PATH_INFO]}))
       end
     end
   end


### PR DESCRIPTION
In particular:

* Style/RedundantParentheses
* Style/SuperWithArgsParentheses