### PR TITLE
Improve Trie implementation when different path variables used in same path location

### DIFF
--- a/lib/hanami/router/leaf.rb
+++ b/lib/hanami/router/leaf.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "mustermann/rails"
+
+module Hanami
+  class Router
+    class Leaf
+      # Trie Leaf
+      #
+      # @api private
+      # @since 2.1.1
+      attr_reader :to, :params
+
+      # @api private
+      # @since 2.1.1
+      def initialize(route, to, constraints)
+        @route = route
+        @to = to
+        @constraints = constraints
+        @params = nil
+      end
+
+      # @api private
+      # @since 2.1.1
+      def match(path)
+        match = matcher.match(path)
+
+        @params = match.named_captures if match
+
+        match
+      end
+
+      private
+
+      # @api private
+      # @since 2.1.1
+      def matcher
+        @matcher ||= Mustermann.new(@route, type: :rails, version: "5.0", capture: @constraints)
+      end
+    end
+  end
+end

--- a/lib/hanami/router/leaf.rb
+++ b/lib/hanami/router/leaf.rb
@@ -8,11 +8,11 @@ module Hanami
       # Trie Leaf
       #
       # @api private
-      # @since 2.1.1
+      # @since 2.2.0
       attr_reader :to, :params
 
       # @api private
-      # @since 2.1.1
+      # @since 2.2.0
       def initialize(route, to, constraints)
         @route = route
         @to = to
@@ -21,7 +21,7 @@ module Hanami
       end
 
       # @api private
-      # @since 2.1.1
+      # @since 2.2.0
       def match(path)
         match = matcher.match(path)
 
@@ -33,7 +33,7 @@ module Hanami
       private
 
       # @api private
-      # @since 2.1.1
+      # @since 2.2.0
       def matcher
         @matcher ||= Mustermann.new(@route, type: :rails, version: "5.0", capture: @constraints)
       end

--- a/lib/hanami/router/node.rb
+++ b/lib/hanami/router/node.rb
@@ -46,7 +46,7 @@ module Hanami
       end
 
       # @api private
-      # @since 2.1.1
+      # @since 2.2.0
       def match(path)
         @leaves&.find { |leaf| leaf.match(path) }
       end

--- a/lib/hanami/router/node.rb
+++ b/lib/hanami/router/node.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "hanami/router/segment"
+require "hanami/router/leaf"
 
 module Hanami
   class Router
@@ -18,15 +18,14 @@ module Hanami
       def initialize
         @variable = nil
         @fixed = nil
-        @to = nil
+        @leaves = nil
       end
 
       # @api private
       # @since 2.0.0
-      def put(segment, constraints)
+      def put(segment)
         if variable?(segment)
-          @variable ||= {}
-          @variable[segment_for(segment, constraints)] ||= self.class.new
+          @variable ||= self.class.new
         else
           @fixed ||= {}
           @fixed[segment] ||= self.class.new
@@ -35,36 +34,21 @@ module Hanami
 
       # @api private
       # @since 2.0.0
-      #
-      def get(segment) # rubocop:disable Metrics/PerceivedComplexity
-        return unless @variable || @fixed
-
-        found = nil
-        captured = nil
-
-        found = @fixed&.fetch(segment, nil)
-        return [found, nil] if found
-
-        @variable&.each do |matcher, node|
-          break if found
-
-          captured = matcher.match(segment)
-          found = node if captured
-        end
-
-        [found, captured&.named_captures]
+      def get(segment)
+        @fixed&.fetch(segment, nil) || @variable
       end
 
       # @api private
       # @since 2.0.0
-      def leaf?
-        @to
+      def leaf!(route, to, constraints)
+        @leaves ||= []
+        @leaves << Leaf.new(route, to, constraints)
       end
 
       # @api private
-      # @since 2.0.0
-      def leaf!(to)
-        @to = to
+      # @since 2.1.1
+      def match(path)
+        @leaves&.find { |leaf| leaf.match(path) }
       end
 
       private
@@ -73,18 +57,6 @@ module Hanami
       # @since 2.0.0
       def variable?(segment)
         Router::ROUTE_VARIABLE_MATCHER.match?(segment)
-      end
-
-      # @api private
-      # @since 2.0.0
-      def segment_for(segment, constraints)
-        Segment.fabricate(segment, **constraints)
-      end
-
-      # @api private
-      # @since 2.0.0
-      def fixed?(matcher)
-        matcher.names.empty?
       end
     end
   end

--- a/lib/hanami/router/trie.rb
+++ b/lib/hanami/router/trie.rb
@@ -22,7 +22,7 @@ module Hanami
       # @api private
       # @since 2.0.0
       def add(route, to, constraints)
-        segments = split(route)
+        segments = segments_from(route)
         node = @root
 
         segments.each do |segment|
@@ -35,7 +35,7 @@ module Hanami
       # @api private
       # @since 2.0.0
       def find(path)
-        segments = split(path)
+        segments = segments_from(path)
         node = @root
 
         return unless segments.all? { |segment| node = node.get(segment) }
@@ -52,7 +52,7 @@ module Hanami
 
       # @api private
       # @since 2.1.1
-      def split(path)
+      def segments_from(path)
         _, *segments = path.split(SEGMENT_SEPARATOR)
 
         segments

--- a/lib/hanami/router/trie.rb
+++ b/lib/hanami/router/trie.rb
@@ -51,7 +51,7 @@ module Hanami
       private_constant :SEGMENT_SEPARATOR
 
       # @api private
-      # @since 2.1.1
+      # @since 2.2.0
       def segments_from(path)
         _, *segments = path.split(SEGMENT_SEPARATOR)
 

--- a/spec/integration/hanami/router/recognition_spec.rb
+++ b/spec/integration/hanami/router/recognition_spec.rb
@@ -601,20 +601,6 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "relative variable with permissive constraint" do
-      let(:router) do
-        described_class.new do
-          get ":test", as: :regex, test: /.*/, to: RecognitionTestCase.endpoint("regex")
-        end
-      end
-
-      it "recognizes route(s)" do
-        runner.run!([
-          [:regex, "/test/", {test: "test"}]
-        ])
-      end
-    end
-
     describe "variable with permissive constraint" do
       let(:router) do
         described_class.new do

--- a/spec/integration/hanami/router/recognition_spec.rb
+++ b/spec/integration/hanami/router/recognition_spec.rb
@@ -256,11 +256,27 @@ RSpec.describe Hanami::Router do
       end
     end
 
-    describe "variable and variable with fixed" do
+    describe "variable followed by variable with fixed with different slug names" do
       let(:router) do
         described_class.new do
           get "/:foo",     as: :variable_one, to: RecognitionTestCase.endpoint("variable_one")
           get "/:bar/baz", as: :variable_two, to: RecognitionTestCase.endpoint("variable_two")
+        end
+      end
+
+      it "recognizes route(s)" do
+        runner.run!([
+          [:variable_one, "/one", {foo: "one"}],
+          [:variable_two, "/two/baz", {bar: "two"}],
+        ])
+      end
+    end
+
+    describe "variable with fixed followed by variable with different slug names" do
+      let(:router) do
+        described_class.new do
+          get "/:bar/baz", as: :variable_two, to: RecognitionTestCase.endpoint("variable_two")
+          get "/:foo",     as: :variable_one, to: RecognitionTestCase.endpoint("variable_one")
         end
       end
 

--- a/spec/integration/hanami/router/recognition_spec.rb
+++ b/spec/integration/hanami/router/recognition_spec.rb
@@ -256,6 +256,22 @@ RSpec.describe Hanami::Router do
       end
     end
 
+    describe "variable and variable with fixed" do
+      let(:router) do
+        described_class.new do
+          get "/:foo",     as: :variable_one, to: RecognitionTestCase.endpoint("variable_one")
+          get "/:bar/baz", as: :variable_two, to: RecognitionTestCase.endpoint("variable_two")
+        end
+      end
+
+      it "recognizes route(s)" do
+        runner.run!([
+          [:variable_one, "/one", {foo: "one"}],
+          [:variable_two, "/two/baz", {bar: "two"}],
+        ])
+      end
+    end
+
     describe "relative variable with constraints" do
       let(:router) do
         described_class.new do

--- a/spec/integration/hanami/router/recognition_spec.rb
+++ b/spec/integration/hanami/router/recognition_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe Hanami::Router do
       it "recognizes route(s)" do
         runner.run!([
           [:variable_one, "/one", {foo: "one"}],
-          [:variable_two, "/two/baz", {bar: "two"}],
+          [:variable_two, "/two/baz", {bar: "two"}]
         ])
       end
     end
@@ -283,7 +283,7 @@ RSpec.describe Hanami::Router do
       it "recognizes route(s)" do
         runner.run!([
           [:variable_one, "/one", {foo: "one"}],
-          [:variable_two, "/two/baz", {bar: "two"}],
+          [:variable_two, "/two/baz", {bar: "two"}]
         ])
       end
     end

--- a/spec/integration/hanami/router/scope_spec.rb
+++ b/spec/integration/hanami/router/scope_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe Hanami::Router do
       app = Rack::MockRequest.new(router)
 
       expect(app.request("GET", "/it", lint: true).body).to eq("Root (it)!")
-      expect(app.request("GET", "/it/", lint: true).body).to eq("Root (it)!")
       expect(app.request("GET", "/it/trees", lint: true).body).to eq("Trees (it)!")
     end
 

--- a/spec/unit/hanami/router/leaf_spec.rb
+++ b/spec/unit/hanami/router/leaf_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "hanami/router/leaf"
+
+RSpec.describe Hanami::Router::Leaf do
+  let(:subject)     { described_class.new(route, to, constraints) }
+  let(:route)       { "/test/route" }
+  let(:to)          { "test proc" }
+  let(:constraints) { {} }
+
+  describe "#initialize" do
+    it "returns a #{described_class} instance" do
+      expect(subject).to be_kind_of(described_class)
+    end
+  end
+  
+  describe "#to" do
+    it "returns the endpoint passed as 'to' when initialized" do
+      expect(subject.to).to eq(to)
+    end
+  end
+  
+  describe "#match" do
+    context "when path matches route" do
+      let(:matching_path)    { route }
+
+      it "returns true" do
+        expect(subject.match(matching_path)).to be_truthy
+      end
+    end
+
+    context "when path doesn't match route" do
+      let(:non_matching_path) { "/bad/path" }
+
+      it "returns true" do
+        expect(subject.match(non_matching_path)).to be_falsey
+      end
+    end
+  end
+
+  describe "#params" do
+    context "without previously calling #match(path)" do
+      it "returns nil" do
+        params = subject.params
+
+        expect(params).to be_nil
+      end
+    end
+
+    context "with variable path" do
+      let(:route)           { "test/:route" }
+      let(:matching_path)   { "test/path" }
+      let(:matching_params) { {"route" => "path"} }
+
+      it "returns captured params" do
+        subject.match(matching_path)
+        params = subject.params
+
+        expect(params).to eq(matching_params)
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/router/leaf_spec.rb
+++ b/spec/unit/hanami/router/leaf_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe Hanami::Router::Leaf do
       expect(subject).to be_kind_of(described_class)
     end
   end
-  
+
   describe "#to" do
     it "returns the endpoint passed as 'to' when initialized" do
       expect(subject.to).to eq(to)
     end
   end
-  
+
   describe "#match" do
     context "when path matches route" do
-      let(:matching_path)    { route }
+      let(:matching_path) { route }
 
       it "returns true" do
         expect(subject.match(matching_path)).to be_truthy

--- a/spec/unit/hanami/router/node_spec.rb
+++ b/spec/unit/hanami/router/node_spec.rb
@@ -10,13 +10,6 @@ RSpec.describe Hanami::Router::Node do
     end
   end
 
-  describe "#put" do
-    it "adds a node matching segment" do
-      segment = "foo"
-      subject.put(segment)
-    end
-  end
-
   describe "#get" do
     context "when segment is found" do
       context "and segment is fixed" do
@@ -45,15 +38,6 @@ RSpec.describe Hanami::Router::Node do
 
         expect(subject.get("bar")).to be_nil
       end
-    end
-  end
-
-  describe "#leaf!" do
-    it "sets leaf data" do
-      route = "/route"
-      to = double("to")
-      constraints = {}
-      subject.leaf!(route, to, constraints)
     end
   end
 

--- a/spec/unit/hanami/router/node_spec.rb
+++ b/spec/unit/hanami/router/node_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "hanami/router/node"
+require "hanami/router/leaf"
+
+RSpec.describe Hanami::Router::Node do
+  describe "#initialize" do
+    it "returns a #{described_class} instance" do
+      expect(subject).to be_kind_of(described_class)
+    end
+  end
+
+  describe "#put" do
+    it "adds a node matching segment" do
+      segment = "foo"
+      subject.put(segment)
+    end
+  end
+
+  describe "#get" do
+    context "when segment is found" do
+      context "and segment is fixed" do
+        it "returns a node" do
+          segment = "foo"
+          subject.put(segment)
+
+          expect(subject.get(segment)).to be_kind_of(described_class)
+        end
+      end
+
+      context "and segment is variable" do
+        it "returns a node" do
+          dynamic_segment = ":foo"
+          subject.put(dynamic_segment)
+
+          expect(subject.get("bar")).to be_kind_of(described_class)
+        end
+      end
+    end
+
+    context "when segment is not found" do
+      it "returns nil" do
+        segment = "foo"
+        subject.put(segment)
+
+        expect(subject.get("bar")).to be_nil
+      end
+    end
+  end
+
+  describe "#leaf!" do
+    it "sets leaf data" do
+      route = "/route"
+      to = double("to")
+      constraints = {}
+      subject.leaf!(route, to, constraints)
+    end
+  end
+
+  describe "#match" do
+    context "when segment is fixed" do
+      context "and match not found" do
+        it "returns nil" do
+          segment = "foo"
+          route = "/foo"
+          to = double("to")
+          constraints = {}
+          path = "/bar"
+          subject.put(segment).leaf!(route, to, constraints)
+
+          expect(subject.get(segment).match(path)).to be_nil
+        end
+      end
+
+      context "and match is found" do
+        it "returns a Leaf object" do
+          segment = "foo"
+          route = "/foo"
+          to = double("to")
+          constraints = {}
+          subject.put(segment).leaf!(route, to, constraints)
+
+          expect(subject.get(segment).match(route)).to be_kind_of(Hanami::Router::Leaf)
+        end
+      end
+    end
+
+    context "when segment is variable" do
+      context "and match not found" do
+        it "returns nil" do
+          segment = ":foo"
+          route = "/:foo"
+          to = double("to")
+          constraints = { foo: :digit }
+          path = "/bar"
+          subject.put(segment).leaf!(route, to, constraints)
+
+          expect(subject.get(segment).match(path)).to be_nil
+        end
+      end
+
+      context "and match found" do
+        it "returns Leaf object" do
+          segment = ":foo"
+          route = "/:foo"
+          to = double("to")
+          constraints = { foo: :digit }
+          path = "/123"
+          subject.put(segment).leaf!(route, to, constraints)
+
+          expect(subject.get(segment).match(path)).to be_kind_of(Hanami::Router::Leaf)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/router/node_spec.rb
+++ b/spec/unit/hanami/router/node_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Hanami::Router::Node do
           segment = ":foo"
           route = "/:foo"
           to = double("to")
-          constraints = { foo: :digit }
+          constraints = {foo: :digit}
           path = "/bar"
           subject.put(segment).leaf!(route, to, constraints)
 
@@ -104,7 +104,7 @@ RSpec.describe Hanami::Router::Node do
           segment = ":foo"
           route = "/:foo"
           to = double("to")
-          constraints = { foo: :digit }
+          constraints = {foo: :digit}
           path = "/123"
           subject.put(segment).leaf!(route, to, constraints)
 

--- a/spec/unit/hanami/router/trie_spec.rb
+++ b/spec/unit/hanami/router/trie_spec.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-require "hanami/middleware/trie"
+require "hanami/router/trie"
 
-RSpec.describe Hanami::Middleware::Trie do
-  subject { described_class.new(app) }
-  let(:app) { -> (*) { [200, {"content-length" => "2"}, ["OK"]] } }
-
+RSpec.describe Hanami::Router::Trie do
   describe "#initialize" do
     it "returns an instance of #{described_class}" do
       expect(subject).to be_kind_of(described_class)
@@ -13,81 +10,76 @@ RSpec.describe Hanami::Middleware::Trie do
   end
 
   describe "#add" do
+    let(:constraints) { {foo: :digit} }
+    let(:empty_constraints) { {} }
+
     it "adds node" do
-      subject.add("/foo", double("foo"))
+      subject.add("/foo", double("foo"), empty_constraints)
     end
-    it "adds multiple fixed segments" do
-      subject.add("/foo/bar/baz", double("foo"))
+
+    it "adds fixed segment" do
+      subject.add("/foo", double("foo"), empty_constraints)
     end
-    it "adds a fixed segment followed by a variable segment" do
-      subject.add("/foo/:bar", double("foo"))
+
+    it "adds variable segment" do
+      subject.add("/:foo", double("foo"), empty_constraints)
     end
+
     it "adds a variable segment followed by a fixed segment" do
-      subject.add("/:foo/bar", double("foo"))
+      subject.add("/:foo/bar", double("foo"), empty_constraints)
     end
+
+    it "adds a variable segment with constraints" do
+      subject.add("/:foo", double("foo"), constraints)
+    end
+
     it "adds a variable segment, and then a variable segment followed by a fixed segment with different variable slugs" do
-      subject.add("/:foo", double("foo"))
-      subject.add("/:bar/foo", double("bar"))
+      subject.add("/:foo", double("foo"), empty_constraints)
+      subject.add("/:bar/foo", double("bar"), empty_constraints)
     end
+
     it "adds a variable segment followed by a fixed segment, and then a variable segment with different variable slugs" do
-      subject.add("/:bar/foo", double("bar"))
-      subject.add("/:foo", double("foo"))
+      subject.add("/:bar/foo", double("bar"), empty_constraints)
+      subject.add("/:foo", double("foo"), empty_constraints)
+    end
+
+    it "adds a variable segment with constriants followed by a variable segment with different variable slugs" do
+      subject.add("/:foo", double("foo"), constraints)
+      subject.add("/:bar", double("bar"), empty_constraints)
     end
   end
 
   describe "#find" do
     before do
-      subject.add("/admin", admin)
-      subject.add("/api", api)
-      subject.add("/api/v1", api_v1)
-      subject.add("/var/:foo", foo)
-      subject.add("/var/:bar/foo", bar)
+      subject.add("/:foo", foo, foo_constraints)
+      subject.add("/:foo/bar", bar, foo_constraints)
+      subject.add("/:baz", baz, empty_constraints)
     end
-    let(:admin) { double("admin") }
-    let(:api) { double("api") }
-    let(:api_v1) { double("api_v1") }
     let(:foo) { double("foo") }
     let(:bar) { double("bar") }
+    let(:baz) { double("baz") }
+    let(:foo_constraints) { {foo: :digit} }
+    let(:empty_constraints) { {} } 
 
-    it "finds nodes by given path" do
-      expect(subject.find("/")).to eq(app)
-      expect(subject.find("/admin")).to eq(admin)
-      expect(subject.find("/admin/")).to eq(admin) # trailing slash
-      expect(subject.find("/api")).to eq(api)
-      expect(subject.find("/api/v1")).to eq(api_v1)
+    it "matches path with variable segment and matching constraints" do
+      to, params = subject.find("/123")
+
+      expect(to).to eq(foo)
+      expect(params).to eq({"foo" => "123"})
     end
 
-    it "matches path prefix" do
-      expect(subject.find("/admin/users")).to eq(admin)
-      expect(subject.find("/api/v1/songs")).to eq(api_v1)
-      expect(subject.find("/api/v1/songs/")).to eq(api_v1) # trailing slash
+    it "matches path with variable segment followed by fixed segment" do
+      to, params = subject.find("/123/bar")
+
+      expect(to).to eq(bar)
+      expect(params).to eq({"foo" => "123"})
     end
 
-    it "matches path with a variable segment" do
-      expect(subject.find("/var/foo")).to eq(foo)
-    end
+    it "matches correct path with variable segment based on constraints" do
+      to, params = subject.find("/qux")
 
-    it "matches path with a variable segment followed by a fixed segment" do
-      expect(subject.find("/var/bar/foo")).to eq(bar)
-    end
-
-    it "falls back to app, if no node is associated with given path" do
-      expect(subject.find("/foo")).to eq(app)
-    end
-  end
-
-  describe "#empty?" do
-    context "without nodes" do
-      it "returns true" do
-        expect(subject).to be_empty
-      end
-    end
-
-    context "with nodes" do
-      it "returns false" do
-        subject.add("/bar", double("bar"))
-        expect(subject).to_not be_empty
-      end
+      expect(to).to eq(baz)
+      expect(params).to eq({"baz" => "qux"})
     end
   end
 end

--- a/spec/unit/hanami/router/trie_spec.rb
+++ b/spec/unit/hanami/router/trie_spec.rb
@@ -9,46 +9,6 @@ RSpec.describe Hanami::Router::Trie do
     end
   end
 
-  describe "#add" do
-    let(:constraints) { {foo: :digit} }
-    let(:empty_constraints) { {} }
-
-    it "adds node" do
-      subject.add("/foo", double("foo"), empty_constraints)
-    end
-
-    it "adds fixed segment" do
-      subject.add("/foo", double("foo"), empty_constraints)
-    end
-
-    it "adds variable segment" do
-      subject.add("/:foo", double("foo"), empty_constraints)
-    end
-
-    it "adds a variable segment followed by a fixed segment" do
-      subject.add("/:foo/bar", double("foo"), empty_constraints)
-    end
-
-    it "adds a variable segment with constraints" do
-      subject.add("/:foo", double("foo"), constraints)
-    end
-
-    it "adds a variable segment, and then a variable segment followed by a fixed segment with different variable slugs" do
-      subject.add("/:foo", double("foo"), empty_constraints)
-      subject.add("/:bar/foo", double("bar"), empty_constraints)
-    end
-
-    it "adds a variable segment followed by a fixed segment, and then a variable segment with different variable slugs" do
-      subject.add("/:bar/foo", double("bar"), empty_constraints)
-      subject.add("/:foo", double("foo"), empty_constraints)
-    end
-
-    it "adds a variable segment with constriants followed by a variable segment with different variable slugs" do
-      subject.add("/:foo", double("foo"), constraints)
-      subject.add("/:bar", double("bar"), empty_constraints)
-    end
-  end
-
   describe "#find" do
     before do
       subject.add("/:foo", foo, foo_constraints)

--- a/spec/unit/hanami/router/trie_spec.rb
+++ b/spec/unit/hanami/router/trie_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Hanami::Router::Trie do
     let(:bar) { double("bar") }
     let(:baz) { double("baz") }
     let(:foo_constraints) { {foo: :digit} }
-    let(:empty_constraints) { {} } 
+    let(:empty_constraints) { {} }
 
     it "matches path with variable segment and matching constraints" do
       to, params = subject.find("/123")

--- a/spec/unit/hanami/router/trie_spec.rb
+++ b/spec/unit/hanami/router/trie_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "hanami/middleware/trie"
+
+RSpec.describe Hanami::Middleware::Trie do
+  subject { described_class.new(app) }
+  let(:app) { -> (*) { [200, {"content-length" => "2"}, ["OK"]] } }
+
+  describe "#initialize" do
+    it "returns an instance of #{described_class}" do
+      expect(subject).to be_kind_of(described_class)
+    end
+  end
+
+  describe "#add" do
+    it "adds node" do
+      subject.add("/foo", double("foo"))
+    end
+    it "adds multiple fixed segments" do
+      subject.add("/foo/bar/baz", double("foo"))
+    end
+    it "adds a fixed segment followed by a variable segment" do
+      subject.add("/foo/:bar", double("foo"))
+    end
+    it "adds a variable segment followed by a fixed segment" do
+      subject.add("/:foo/bar", double("foo"))
+    end
+    it "adds a variable segment, and then a variable segment followed by a fixed segment with different variable slugs" do
+      subject.add("/:foo", double("foo"))
+      subject.add("/:bar/foo", double("bar"))
+    end
+    it "adds a variable segment followed by a fixed segment, and then a variable segment with different variable slugs" do
+      subject.add("/:bar/foo", double("bar"))
+      subject.add("/:foo", double("foo"))
+    end
+  end
+
+  describe "#find" do
+    before do
+      subject.add("/admin", admin)
+      subject.add("/api", api)
+      subject.add("/api/v1", api_v1)
+      subject.add("/var/:foo", foo)
+      subject.add("/var/:bar/foo", bar)
+    end
+    let(:admin) { double("admin") }
+    let(:api) { double("api") }
+    let(:api_v1) { double("api_v1") }
+    let(:foo) { double("foo") }
+    let(:bar) { double("bar") }
+
+    it "finds nodes by given path" do
+      expect(subject.find("/")).to eq(app)
+      expect(subject.find("/admin")).to eq(admin)
+      expect(subject.find("/admin/")).to eq(admin) # trailing slash
+      expect(subject.find("/api")).to eq(api)
+      expect(subject.find("/api/v1")).to eq(api_v1)
+    end
+
+    it "matches path prefix" do
+      expect(subject.find("/admin/users")).to eq(admin)
+      expect(subject.find("/api/v1/songs")).to eq(api_v1)
+      expect(subject.find("/api/v1/songs/")).to eq(api_v1) # trailing slash
+    end
+
+    it "matches path with a variable segment" do
+      expect(subject.find("/var/foo")).to eq(foo)
+    end
+
+    it "matches path with a variable segment followed by a fixed segment" do
+      expect(subject.find("/var/bar/foo")).to eq(bar)
+    end
+
+    it "falls back to app, if no node is associated with given path" do
+      expect(subject.find("/foo")).to eq(app)
+    end
+  end
+
+  describe "#empty?" do
+    context "without nodes" do
+      it "returns true" do
+        expect(subject).to be_empty
+      end
+    end
+
+    context "with nodes" do
+      it "returns false" do
+        subject.add("/bar", double("bar"))
+        expect(subject).to_not be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
@kyleplump and I collaborated on this PR.

## Summary

Router cannot differentiate between multiple defined routes that contain different path variable names in the same location. For example:

```ruby
get "/:id/edit"
get "/:uuid"
```

This PR changes the router behavior to group all variable slugs together for matching purposes and to lazily create and evaluate Mustermann matchers. Discussion below.

The above symptom is illustrated in other open issues, such as #255 (Routes with multiple variables not working in common nested route scenario) and  #256 (Inconsistent trailing slash behaviour). Although trailing slashes are not a documented use case, they sometimes work (and sometimes don't) due to segment-by-segment matching.

The proposed implementation should close #255 , #256 , and #272 , by applying complete route matchers that provide consistent, predictable behavior, as documented in the current Hanami Guides.

We also suggest closing #247 (Failing edge cases for optional variables) as an undocumented use case that is not currently supported. Optional segments are not supported by either the current router or the proposed update.

Closes #247 
Closes #255
Closes #256 
Closes #272 

## Discussion

### Current Router Behavior

Hanami Router 2.0 uses a trie data structure to build a representation of all routes that contain a "dynamic segment," a.k.a., a path variable. It should be noted that all routes that contain only fixed segments are stored in a separate Hash where they can be looked up directly.

Notable features of the current router:

- Routes are stored in the trie as nodes based on each segment of the route (segments defined by the "/" delimiter in the route).
- For path variables/dynamic segments, a Mustermann matcher is created and stored in the trie node, with the matcher used as the key for the node.
- When matching an incoming path to a route, the trie evaluates each segment of the path and calculates and collects derived parameter values *from each dynamic segment as it goes* (this is important).

Because the Mustermann matcher for each dynamic segment is used as the key for that node, different matchers will result in different nodes being created, even if the dynamic segments in question are in parallel locations in different routes.

That is, in the route example above, different matchers would be created for `:id` and `:uuid`, since different path variable names are used.  However, the same node would be have been used for both routes if the same path variable name had been used (say, `:id`). It is worth noting also that different matchers (and therefore different nodes) would also be created if the same path variable names were used, but with different constraints.

The problem arises when matching paths and collecting parameters on the fly, as illustrated below.

The following routes:

```ruby
get "/:id/edit"
get "/:id"
```

Would produce a trie like this:

```mermaid
flowchart LR
  A((root))-->B(((":id")))
  B-->C((("edit")))
```

Where the double circles represent potential path endpoints, so both `:id` and `edit` are potential path endpoints.

In this case, the router has no trouble matching either `/1234` or `/1234/edit` to the correct routes.

However, if the following routes are used:

```ruby
get "/:id/edit"
get "/:uuid"
```

A trie like this will be created:

```mermaid
flowchart LR
  A((root))-->B((":id"))
  B-->C((("edit")))
  A-->D(((":uuid")))
```

Here, `:id` and `:uuid` are different nodes, and `:id` is no longer an endpoint. Now, when the router tries to match a path like "/9d5794e7-12ed-4f00-a6d1-a5be9cd4072e", it has no way to know that this is a UUID and incorrectly matches it to the `:id` node. Crucially, the UUID is collected and stored in the params Hash under the key `:id`. When the router then realizes that this path does not match any route at or below the `:id` node, it has no way to backtrack, "forget" the incorrect `:id` param, and search down a different node path. In fact, backtracking in this way is contrary to trie design and would essentially convert the trie to an ordinary tree data structure.

### Proposed Router Behavior

The proposed router behavior is to store a single variable node for all dynamic segments that are defined in parallel locations in an app's route table. Also, rather than attempting to parse and collect path variable params on the fly, the proposed router delays the creation and evaluation of Mustermann matchers until a potential full path/route match has been identified.

The following routes:

```ruby
get "/:id/edit"
get "/:uuid"
```

Would now create a trie like this:

```mermaid
flowchart LR
  A((root))-->B(((":*")))
  B-->C((("edit")))
```

And each endpoint would contain the information needed to create and evaluate a matcher for a proposed path that evaluates to that endpoint.

## Tests

The proposed implementation adds a new class, Leaf, and refactors the Trie and Node classes. New unit tests are included for each of these classes. New integration tests are also included (in `recognition_spec.rb`). All of these tests are passing.

The proposed implementation breaks two existing tests, [here](https://github.com/hanami/router/blob/e9c15474ec182a1094d933160c6635e7c0afe63c/spec/integration/hanami/router/recognition_spec.rb#L572-L584) and [here](https://github.com/hanami/router/blob/e9c15474ec182a1094d933160c6635e7c0afe63c/spec/integration/hanami/router/scope_spec.rb#L47-L61). These tests each break for reasons that merit further, separate discussion in another comment below, but we believe these tests exercise undocumented behavior and should be changed or deleted. In the alternative, if this behavior is desired, it should be documented and described and we would be happy to try to implement it accordingly.

Interestingly, there is also a commented-out test [here](https://github.com/hanami/router/blob/e9c15474ec182a1094d933160c6635e7c0afe63c/spec/integration/hanami/router/recognition_spec.rb#L552-L570) that documents the current issue, and now passes with the proposed changes. :nerd_face: 

## Conclusion

With guidance, we will delete or modify the breaking tests or, in the alternative, implement whatever documented behavior is desired for these use cases.

Finally, performance is important in this gem. We believe it is possible that the proposed implementation is faster than the current one, but we have not performance tested it. We have no reason to believe it will be slower. Memory usage is also not tested, but we believe fewer objects will be created with the proposed changes.

Thank you!