### PR TITLE
speed up new router implementation

### DIFF
--- a/lib/hanami/router/leaf.rb
+++ b/lib/hanami/router/leaf.rb
@@ -18,6 +18,7 @@ module Hanami
         @to = to
         @constraints = constraints
         @params = nil
+        @matcher = Mustermann.new(@route, type: :rails, version: "5.0", capture: @constraints)
       end
 
       # @api private


### PR DESCRIPTION
related to [#278](https://github.com/hanami/router/issues/278)

in the new Trie `leaf` implementation, Mustermann matchers were created at the time of evaluation, causing a semi-significant slowdown.  we have all of the information to create the matcher when building the trie - so, this fix creates the matcher at the time of `leaf` creation (leaving a fallback in `#match`), while maintaining the benefits of having `leaves` as introduced in 2.2, with this [PR](https://github.com/hanami/router/pull/273)

this brings us back to similar performance as `hanami-router v2.1`, with the exception of startup (this fix is temporarily called `2.2.1`):

![rps](https://github.com/user-attachments/assets/e4a135d5-53f5-49ca-8be0-acab1d4674d9)
![log_rps](https://github.com/user-attachments/assets/5a31d0b9-a928-4a32-8103-71fa2db5d4f0)
![runtime_with_startup](https://github.com/user-attachments/assets/4514f85f-abb1-42da-8d3c-2d72485ce156)

this slowdown on boot is expected - more work (creating leaves / mustermann) is happening.  the way to get around this would likely be a new structure other than a trie (maybe someday!), or maybe evaluating / building the trie async (😬)

please let me know if you'd like more test cases (especially looking for thoughts from @dcr8898) . thanks!
