### PR TITLE
Convert dash (and more) to underscore in URL helper names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Rack compatible HTTP router for Ruby
 
+## [Unreleased]
+
+### Changed
+
+- [Sven Schwyn] Convert -, +, ~, and . to underscore in URL helper names (#280)
+
 ## v2.2.0 - 2024-11-05
 
 ### Changed

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -693,6 +693,10 @@ module Hanami
     # @api private
     PREFIXED_NAME_SEPARATOR = "_"
 
+    # @since x.x.x
+    # @api private
+    UNDERSCORED_NAME_REGEXP = /[\-+~.]/
+
     # @since 2.0.0
     # @api private
     ROOT_PATH = "/"
@@ -800,7 +804,7 @@ module Hanami
       end
 
       if as
-        as = prefixed_name(as)
+        as = prefixed_underscored_name(as)
         add_named_route(path, as, constraints)
       end
 
@@ -872,10 +876,13 @@ module Hanami
       @path_prefix.join(path).to_s
     end
 
-    # @since 2.0.0
+    # @since x.x.x
     # @api private
-    def prefixed_name(name)
-      @name_prefix.relative_join(name, PREFIXED_NAME_SEPARATOR).to_sym
+    def prefixed_underscored_name(name)
+      @name_prefix
+        .relative_join(name, PREFIXED_NAME_SEPARATOR)
+        .gsub(UNDERSCORED_NAME_REGEXP, "_")
+        .to_sym
     end
 
     # Returns a new instance of Hanami::Router with the modified options.

--- a/spec/unit/hanami/router/url_spec.rb
+++ b/spec/unit/hanami/router/url_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Hanami::Router do
       get "/books/:id", id: /\d+/, to: e, as: :constraints
       get "/articles(.:format)",   to: e, as: :optional
       get "/files/*glob",          to: e, as: :glob
+      scope "/a-b+c~d.e" do
+        get "/hanami", to: e, as: :scoped
+      end
     end
   end
 
@@ -45,6 +48,10 @@ RSpec.describe Hanami::Router do
 
     it "escapes additional params in query string" do
       expect(router.url(:fixed, return_to: "/dashboard")).to eq(URI("#{base_url}/hanami?return_to=%2Fdashboard"))
+    end
+
+    it "prefixes the scope using underscores" do
+      expect(router.url(:a_b_c_d_e_scoped)).to eq(URI("#{base_url}/a-b+c~d.e/hanami"))
     end
 
     # FIXME: should preserve this behavior?


### PR DESCRIPTION
Given a scope (or by extension: a slice) which contains dash `-`, plus `+`, tilde `~` or dot `.` in their URL fragment:

```ruby
# config/routes.rb

module Dashy
  class Routes < Hanami::Routes
    scope "my-scope" do
      get "foo", to: "action.foo", as: :foo
    end
  end
end
```

The dashes etc. are converted to underscores for the corresponding URL helper name:

```
% hanami routes

GET   /my-slice/foo   action.foo   as :my_slice_foo
        ^^^                             ^^^
```

Closes #280