### PR TITLE
Allow absolute redirects in router

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,12 +349,17 @@ __Hanami::Router__ uses [Semantic Versioning 2.0.0](http://semver.org)
 
 ## Contributing
 
-1. Fork it
+1. Fork this repo to your account and clone it locally (`git clone git@github.com:your-pseudo/your-cloned-repo.git`)
 2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+3. Install the dependencies (`bundle install`)
+4. Run tests, they should all pass (`bundle exec rake`)
+5. Make your changes & check that the tests still pass. Add some test cases if needed.
+6. Commit your changes (`git commit -am 'Add some feature'`)
+7. Push to the branch (`git push origin my-new-feature`)
+8. Create new Pull Request on Github with some context on what you're trying to fix or to improve with this contribution
+
+Thank you for contributing! 
 
 ## Copyright
 
-Copyright © 2014–2024 Hanami Team – Released under MIT License
+Copyright © 2014–2025 Hanami Team – Released under MIT License

--- a/lib/hanami/router.rb
+++ b/lib/hanami/router.rb
@@ -907,7 +907,11 @@ module Hanami
         raise UnknownHTTPStatusCodeError.new(code)
       end
 
-      destination = prefixed_path(to)
+      destination = if to =~ /^https?:\/\//i
+        to
+      else
+        prefixed_path(to)
+      end
       Redirect.new(destination, code, ->(*) { [code, {HTTP_HEADER_LOCATION => destination}, [body]] })
     end
 

--- a/spec/unit/hanami/router/redirect_spec.rb
+++ b/spec/unit/hanami/router/redirect_spec.rb
@@ -29,5 +29,31 @@ RSpec.describe Hanami::Router do
       expect(status).to eq(302)
       expect(headers["Location"]).to eq("/redirect_destination")
     end
+
+    it "recognizes string endpoint with absolute url" do
+      router   = Hanami::Router.new do
+        redirect "/redirect", to: "https://hanamirb.org/"
+      end
+
+      env = Rack::MockRequest.env_for("/redirect")
+      status, headers, = router.call(env)
+
+      expect(status).to eq(301)
+      expect(headers["Location"]).to eq("https://hanamirb.org/")
+    end
+
+    it "recognizes string endpoint with relative path that start like an absolute url but is not" do
+      endpoint = ->(_env) { [200, {}, ["Redirect destination!"]] }
+      router   = Hanami::Router.new do
+        get "/http:redirect_destination", to: endpoint, as: :destination
+        redirect "/redirect", to: "/http:redirect_destination"
+      end
+
+      env = Rack::MockRequest.env_for("/redirect")
+      status, headers, = router.call(env)
+
+      expect(status).to eq(301)
+      expect(headers["Location"]).to eq("/http:redirect_destination")
+    end
   end
 end


### PR DESCRIPTION
In the routing of Hanami 1.x, it was possible to redirect with an absolute URL, for example with this directive:
`redirect '/v1', to: https://my-external-domain.com, code: 302`

It is not currently possible to do that with Hanami 2.x.: this Pull Request aims at allowing that,by detection http:// patterns 
I've added some tests to support that.

I'm also proposing a bit more details in the "contributing" section of the README, let me know what you think.
