### PR TITLE
Add Rack 2/3 to CI build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           - "3.3"
           - "3.2"
           - "3.1"
+        rack:
+          - "~> 2.0"
+          - "~> 3.0"
     steps:
       - uses: actions/checkout@v4
       - name: Install package dependencies
@@ -27,8 +30,12 @@ jobs:
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true # 'bundle install' and cache gems
+        env:
+          RACK_VERSION_CONSTRAINT: ${{matrix.rack}}
       - name: Run all tests
         run: script/ci
+        env:
+          RACK_VERSION_CONSTRAINT: ${{matrix.rack}}
 
   workflow-keepalive:
     if: github.event_name == 'schedule'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         rack:
           - "~> 2.0"
           - "~> 3.0"
+    name: tests (Ruby ${{ matrix.ruby }}, Rack ${{ matrix.rack }})
     steps:
       - uses: actions/checkout@v4
       - name: Install package dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,9 @@ unless ENV["CI"]
   gem "yard-junk"
 end
 
+if ENV["RACK_VERSION_CONSTRAINT"]
+  gem "rack", ENV["RACK_VERSION_CONSTRAINT"]
+end
+
 gem "hanami-devtools", github: "hanami/devtools", branch: "main"
 gem "rexml"

--- a/spec/integration/hanami/router/routing_spec.rb
+++ b/spec/integration/hanami/router/routing_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Hanami::Router do
           end
 
           context "block" do
-            let(:response) { Rack::MockResponse.new(200, rack_headers({}), "Block!") }
+            let(:response) { Rack::MockResponse.new(200, block_content_length_headers("Block!"), "Block!") }
 
             it "recognizes" do
               expect(app.request(verb.upcase, "/block", lint: true)).to eq_response(response)
@@ -207,12 +207,20 @@ RSpec.describe Hanami::Router do
             end
           end
 
-          let(:response) { Rack::MockResponse.new(200, rack_headers({}), "Block!") }
+          let(:response) { Rack::MockResponse.new(200, block_content_length_headers("Block!"), "Block!") }
 
           it "recognizes" do
             expect(app.request("GET", "/", lint: true)).to eq_response(response)
           end
         end
+      end
+    end
+
+    def block_content_length_headers(body)
+      if Hanami::Router.rack_3?
+        rack_headers({})
+      else
+        rack_headers({"Content-Length" => body.length.to_s})
       end
     end
   end


### PR DESCRIPTION
The Rack 2 tests are all failing (proving this is a necessary change!), due to Content-Length header being present when we expect it to be empty. That change was made in this commit: https://github.com/hanami/router/pull/277/commits/2323a3669b0a1053cda1840143518c370cb8777f, and related to this comment: https://github.com/hanami/router/pull/277#issuecomment-3142177837

~I think we don't want to change what we were doing for Rack 2, so we should set the response to have a Content-Length for Rack 2, and not have one for Rack 3? WDYT @timriley~

Update: so the issue was only for block responses. Rack 2 does set Content-Length for blocks, while [Rack 3 does not](https://github.com/rack/rack/blob/b68251c03788ff39d4a4b25424df7360426e4afd/lib/rack/response.rb#L114-L117), so I added a helper method for that. 

Note that there's an optimization that could be made in the implementation, and just avoid rack_headers altogether since they have the same conditional, with different behavior, so it could be simplified as:

```ruby
if Hanami::Router.rack_3?
  Rack::Headers.new
else
  {"Content-Length" => body.length.to_s}
end
```

But I think keeping it consistent with the others in the file, i.e. always using the `rack_headers` helper, is simpler to follow, though it's unoptimized. Since it's just test code (and negligible), I think we should keep it as-is.

Can you confirm this is correct @kyleplump @timriley ?